### PR TITLE
Add support to disable hostname verification

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -72,6 +72,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EMPTY_STRING;
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.SOCKET_IDEAL_TIMEOUT_VALUE;
+import static org.wso2.extension.siddhi.io.http.util.HttpConstants.TRUE;
 
 /**
  * {@code HttpSink } Handle the HTTP publishing tasks.
@@ -398,6 +399,12 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.SOCKET_IDEAL_
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = " "),
+                @Parameter(
+                        name = "hostname.verification.enabled",
+                        description = "To enable hostname verification",
+                        type = {DataType.BOOL},
+                        optional = true,
+                        defaultValue = "true"),
         },
         examples = {
                 @Example(syntax =
@@ -524,6 +531,7 @@ public class HttpSink extends Sink {
     private String authType;
     private AccessTokenCache accessTokenCache = AccessTokenCache.getInstance();
     private String tokenURL;
+    private String hostnameVerificationEnabled;
 
     private HttpWsConnectorFactory httpConnectorFactory;
 
@@ -615,6 +623,8 @@ public class HttpSink extends Sink {
         bootstrapBoss = configReader.readConfig(HttpConstants.CLIENT_BOOTSTRAP_BOSS_GROUP_SIZE, EMPTY_STRING);
         bootstrapClient = configReader.readConfig(HttpConstants.CLIENT_BOOTSTRAP_CLIENT_GROUP_SIZE,
                 EMPTY_STRING);
+        hostnameVerificationEnabled = optionHolder.validateAndGetStaticValue(
+                HttpConstants.HOSTNAME_VERIFICATION_ENABLED, TRUE);
         if (!HttpConstants.EMPTY_STRING.equals(userName) && !HttpConstants.EMPTY_STRING.equals(userPassword)) {
             authType = HttpConstants.BASIC_AUTH;
         } else if ((!HttpConstants.EMPTY_STRING.equals(consumerKey)
@@ -1143,6 +1153,9 @@ public class HttpSink extends Sink {
         */
         if (!EMPTY_STRING.equals(parametersList)) {
             senderConfig.setParameters(HttpIoUtil.populateParameters(parametersList));
+        }
+        if (!TRUE.equalsIgnoreCase(hostnameVerificationEnabled)) {
+            senderConfig.setHostNameVerificationEnabled(false);
         }
 
         //overwrite default transport configuration

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -238,4 +238,5 @@ public class HttpConstants {
     public static final String ACCESS_TOKEN = "access_token";
     public static final String REFRESH_TOKEN = "refresh_token";
     public static final String BLOCKING_IO = "blocking.io";
+    public static final String HOSTNAME_VERIFICATION_ENABLED = "hostname.verification.enabled";
 }


### PR DESCRIPTION
## Purpose
Add support to disable hostname verification

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
