### PR TITLE
Introudce properties for pool configurations

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpRequestSink.java
@@ -721,7 +721,7 @@ public class HttpRequestSink extends HttpSink {
         HttpResponseFuture httpResponseFuture = clientConnector.send(cMessage);
         HttpResponseMessageListener httpListener;
         CountDownLatch latch = isBlockingIO ? responseLatch : new CountDownLatch(1);
-        httpListener = new HttpResponseMessageListener(getTrpProperties(dynamicOptions), sinkId,
+        httpListener = new HttpResponseMessageListener(this, getTrpProperties(dynamicOptions), sinkId,
                 isDownloadEnabled, latch, tryCount, authType, isBlockingIO);
         httpResponseFuture.setHttpConnectorListener(httpListener);
 

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -57,6 +57,7 @@ import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.contract.config.ProxyServerConfiguration;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contractimpl.DefaultHttpWsConnectorFactory;
+import org.wso2.transport.http.netty.contractimpl.sender.channel.pool.PoolConfiguration;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
 import java.io.UnsupportedEncodingException;
@@ -297,61 +298,84 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.TRUE;
                         optional = true,
                         defaultValue = "15"),
 
+                // pool configurations
                 @Parameter(
-                        name = "client.threadpool.configurations",
-                        description = "Thread pool configuration. Expected format of these parameters is as follows:" +
-                                " \"'client.connection.pool.count:xxx','client.max.active.connections.per.pool:xxx'\"",
-                        type = {DataType.STRING},
-                        optional = true,
-                        defaultValue = "TODO"),
-                @Parameter(
-                        name = "client.connection.pool.count",
-                        description = "Connection pool count.",
+                        name = "connection.pool.count",
+                        description = "Number of connection pools that need to be created for the particular client.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "0"),
                 @Parameter(
-                        name = "client.max.active.connections.per.pool",
-                        description = "Active connections per pool.",
+                        name = "max.active.connections.per.pool",
+                        description = "Maximum possible number of active connection per pool for the client.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "-1"),
                 @Parameter(
-                        name = "client.min.idle.connections.per.pool",
-                        description = "Minimum ideal connection per pool.",
+                        name = "min.idle.connections.per.pool",
+                        description = "Minimum allowed number of idle connections that can be existed in a pool of " +
+                                "the client.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "0"),
                 @Parameter(
-                        name = "client.max.idle.connections.per.pool",
-                        description = "Maximum ideal connection per pool.",
+                        name = "max.idle.connections.per.pool",
+                        description = "Maximum number of idle connections that can be existed in a pool of the " +
+                                "client.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "100"),
                 @Parameter(
-                        name = "client.min.eviction.idle.time",
-                        description = "Minimum eviction idle time.",
+                        name = "min.evictable.idle.time",
+                        description = "Minimum amount of time (in milliseconds) a connection may sit idle in the pool" +
+                                " before it is eligible for eviction.",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = "5 * 60 * 1000"),
+                        defaultValue = "300000ms"),
                 @Parameter(
-                        name = "sender.thread.count",
-                        description = "Http sender thread count.",
+                        name = "time.between.eviction.runs",
+                        description = "Time between two eviction operations (in miliseconds) on the connection pool",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = "20"),
+                        defaultValue = "30000ms"),
                 @Parameter(
-                        name = "event.group.executor.thread.size",
-                        description = "Event group executor thread size.",
-                        type = {DataType.STRING},
-                        optional = true,
-                        defaultValue = "15"),
-                @Parameter(
-                        name = "max.wait.for.client.connection.pool",
-                        description = "Maximum wait for client connection pool.",
+                        name = "max.wait.time",
+                        description = "The maximum number of milliseconds that the pool will wait " +
+                                "(when there are no available connections) for a connection to be returned.",
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = "60000"),
+                @Parameter(
+                        name = "test.on.borrow",
+                        description = "The indication of whether objects will be validated " +
+                                "before being borrowed from the pool. " +
+                                "If the object validation is failed, it will be dropped from the pool, " +
+                                "and will attempt to borrow another.",
+                        type = {DataType.BOOL},
+                        optional = true,
+                        defaultValue = "true"),
+                @Parameter(
+                        name = "test.while.idle",
+                        description = "The indication of whether objects will be validated " +
+                                "by the idle object evictor (if any). " +
+                                "If the object validation is failed, it will be dropped from the pool.",
+                        type = {DataType.BOOL},
+                        optional = true,
+                        defaultValue = "true"),
+                @Parameter(
+                        name = "exhausted.action",
+                        description = "Action which should be taken when the maximum number of active connections " +
+                                "are being used. This action is indicated as an integer. Possible action are as " +
+                                "following.\n" +
+                                "0 - Fail the request when pool is exhausted\n" +
+                                "1 - Block the request when pool is exhausted, until a connection return to the " +
+                                "pool\n" +
+                                "2 - Grow the connection pool size when it's exhausted",
+                        type = {DataType.INT},
+                        optional = true,
+                        defaultValue = "1 (Block when exhausted)"),
+
+
                 @Parameter(
                         name = "oauth.username",
                         description = "The username to be included in the authentication header of the oauth " +
@@ -361,7 +385,7 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.TRUE;
                                 " requests ",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = " "),
+                        defaultValue = "NONE"),
                 @Parameter(
                         name = "oauth.password",
                         description = "The password to be included in the authentication header of the oauth " +
@@ -371,20 +395,20 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.TRUE;
                                 " requests ",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = " "),
+                        defaultValue = "NONE"),
                 @Parameter(
                         name = "consumer.key",
                         description = "consumer key for the Http request. It is only applicable for for Oauth requests",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = " "),
+                        defaultValue = "NONE"),
                 @Parameter(
                         name = "consumer.secret",
                         description = "consumer secret for the Http request. It is only applicable for for " +
                                 "Oauth requests",
                         type = {DataType.STRING},
                         optional = true,
-                        defaultValue = " "),
+                        defaultValue = "NONE"),
                 @Parameter(
                         name = "refresh.token",
                         description = "refresh token for the Http request. It is only applicable for for" +
@@ -511,8 +535,6 @@ public class HttpSink extends Sink {
     private String sslProtocol;
     private String tlsStoreType;
     private String chunkDisabled;
-    private String followRedirect;
-    private String maxRedirectCount;
     private String parametersList;
     private String proxyHost;
     private String proxyPort;
@@ -531,6 +553,16 @@ public class HttpSink extends Sink {
     private String authType;
     private AccessTokenCache accessTokenCache = AccessTokenCache.getInstance();
     private String tokenURL;
+    private int maxActivePerPool;
+    private int minIdlePerPool;
+    private int maxIdlePerPool;
+    private boolean testOnBorrow;
+    private boolean testWhileIdle;
+    private long timeBetweenEvictionRuns;
+    private long minEvictableIdleTime;
+    private byte exhaustedAction;
+    private int numberOfPools;
+    private long maxWaitTime;
     private String hostnameVerificationEnabled;
 
     private HttpWsConnectorFactory httpConnectorFactory;
@@ -593,7 +625,7 @@ public class HttpSink extends Sink {
                 EMPTY_STRING);
         this.refreshToken = optionHolder.getOrCreateOption(HttpConstants.RECEIVER_REFRESH_TOKEN, EMPTY_STRING);
         this.tokenURL = optionHolder.validateAndGetStaticValue(HttpConstants.TOKEN_URL, EMPTY_STRING);
-        clientStoreFile = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_TRUSTSTORE_PATH_PARAM,
+        this.clientStoreFile = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_TRUSTSTORE_PATH_PARAM,
                 HttpSinkUtil.trustStorePath(configReader));
         clientStorePass = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_TRUSTSTORE_PASSWORD_PARAM,
                 HttpSinkUtil.trustStorePassword(configReader));
@@ -602,10 +634,29 @@ public class HttpSink extends Sink {
         sslProtocol = optionHolder.validateAndGetStaticValue(HttpConstants.SSL_PROTOCOL, EMPTY_STRING);
         tlsStoreType = optionHolder.validateAndGetStaticValue(HttpConstants.TLS_STORE_TYPE, EMPTY_STRING);
         chunkDisabled = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_CHUNK_ENABLED, EMPTY_STRING);
-        followRedirect = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_FOLLOW_REDIRECT,
-                EMPTY_STRING);
-        maxRedirectCount = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_MAX_REDIRECT_COUNT,
-                EMPTY_STRING);
+
+        //pool configurations
+        maxIdlePerPool = Integer.parseInt(optionHolder.validateAndGetStaticValue(
+                HttpConstants.MAX_IDLE_CONNECTIONS_PER_POOL, HttpConstants.DEFAULT_MAX_IDLE_CONNECTIONS_PER_POOL));
+        minIdlePerPool = Integer.parseInt(optionHolder.validateAndGetStaticValue(
+                HttpConstants.MIN_IDLE_CONNECTIONS_PER_POOL, HttpConstants.DEFAULT_MIN_IDLE_CONNECTIONS_PER_POOL));
+        maxActivePerPool = Integer.parseInt(optionHolder.validateAndGetStaticValue(
+                HttpConstants.MAX_ACTIVE_CONNECTIONS_PER_POOL, HttpConstants.DEFAULT_MAX_ACTIVE_CONNECTIONS_PER_POOL));
+        testOnBorrow = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(HttpConstants.TEST_ON_BORROW,
+                HttpConstants.DEFAULT_TEST_ON_BORROW));
+        testWhileIdle = Boolean.parseBoolean(optionHolder.validateAndGetStaticValue(HttpConstants.TEST_WHILE_IDLE,
+                HttpConstants.DEFAULT_TEST_WHILE_IDLE));
+        timeBetweenEvictionRuns = Long.parseLong(optionHolder.validateAndGetStaticValue(
+                HttpConstants.TIME_BETWEEN_EVICTION_RUNS, HttpConstants.DEFAULT_TIME_BETWEEN_EVICTION_RUNS));
+        minEvictableIdleTime = Long.parseLong(optionHolder.validateAndGetStaticValue(
+                HttpConstants.MIN_EVICTABLE_IDLE_TIME, HttpConstants.DEFAULT_MIN_EVICTABLE_IDLE_TIME));
+        exhaustedAction = (byte) Integer.parseInt(optionHolder.validateAndGetStaticValue(
+                HttpConstants.EXHAUSTED_ACTION, HttpConstants.DEFAULT_EXHAUSTED_ACTION));
+        numberOfPools = Integer.parseInt(optionHolder.validateAndGetStaticValue(HttpConstants.CONNECTION_POOL_COUNT,
+                HttpConstants.DEFAULT_CONNECTION_POOL_COUNT));
+        maxWaitTime = Integer.parseInt(optionHolder.validateAndGetStaticValue(
+                HttpConstants.MAX_WAIT_TIME,  HttpConstants.DEFAULT_MAX_WAIT_TIME));
+
         parametersList = optionHolder.validateAndGetStaticValue(HttpConstants.SINK_PARAMETERS, EMPTY_STRING);
         proxyHost = optionHolder.validateAndGetStaticValue(HttpConstants.PROXY_HOST, EMPTY_STRING);
         proxyPort = optionHolder.validateAndGetStaticValue(HttpConstants.PROXY_PORT, EMPTY_STRING);
@@ -992,9 +1043,6 @@ public class HttpSink extends Sink {
      */
     HttpCarbonMessage generateCarbonMessage(List<Header> headers, String contentType,
                                             String httpMethod, HttpCarbonMessage cMessage) {
-        /*
-         * set carbon message properties which is to be used in carbon transport.
-         */
         // Set protocol type http or https
         cMessage.setProperty(Constants.PROTOCOL, httpURLProperties.get(Constants.PROTOCOL));
         // Set uri
@@ -1018,10 +1066,8 @@ public class HttpSink extends Sink {
                     "supported.");
         }
 
+        //Set request headers.
         httpHeaders.set(Constants.HTTP_HOST, cMessage.getProperty(Constants.HTTP_HOST));
-        /*
-         *set request headers.
-         */
         // Set user given Headers
         if (headers != null) {
             for (Header header : headers) {
@@ -1063,7 +1109,7 @@ public class HttpSink extends Sink {
         }
     }
 
-    void initClientConnector(DynamicOptions dynamicOptions) {
+    public void initClientConnector(DynamicOptions dynamicOptions) {
         if (publisherURLOption.isStatic()) {
             publisherURL = publisherURLOption.getValue();
         } else {
@@ -1120,10 +1166,24 @@ public class HttpSink extends Sink {
                 }
                 senderConfig.setProxyServerConfiguration(proxyServerConfiguration);
             } catch (UnknownHostException e) {
-                log.error("Proxy url and password is invalid in sink " + streamID + " Siddhi app " +
+                log.error("Proxy url and password is invalid in sink " + streamID + " of siddhi app " +
                         siddhiAppContext.getName(), e);
             }
         }
+
+        PoolConfiguration poolConfiguration = new PoolConfiguration();
+        poolConfiguration.setMaxActivePerPool(maxActivePerPool);
+        poolConfiguration.setMinIdlePerPool(minIdlePerPool);
+        poolConfiguration.setMaxIdlePerPool(maxIdlePerPool);
+        poolConfiguration.setTestOnBorrow(testOnBorrow);
+        poolConfiguration.setTestWhileIdle(testWhileIdle);
+        poolConfiguration.setTimeBetweenEvictionRuns(timeBetweenEvictionRuns);
+        poolConfiguration.setMinEvictableIdleTime(minEvictableIdleTime);
+        poolConfiguration.setExhaustedAction(exhaustedAction);
+        poolConfiguration.setNumberOfPools(numberOfPools);
+        poolConfiguration.setMaxWaitTime(maxWaitTime);
+        senderConfig.setPoolConfiguration(poolConfiguration);
+
         //add advanced sender configurations
         if (socketIdleTimeout != -1) {
             senderConfig.setSocketIdleTimeout(socketIdleTimeout);
@@ -1143,14 +1203,6 @@ public class HttpSink extends Sink {
                 }
             }
         }
-        // TODO: 27/02/19 Add redirection support
-       /* if (!EMPTY_STRING.equals(followRedirect)) {
-            senderConfig.setFollowRedirect(Boolean.parseBoolean(followRedirect));
-        }
-        if (!EMPTY_STRING.equals(maxRedirectCount)) {
-            senderConfig.setMaxRedirectCount(Integer.parseInt(maxRedirectCount));
-        }
-        */
         if (!EMPTY_STRING.equals(parametersList)) {
             senderConfig.setParameters(HttpIoUtil.populateParameters(parametersList));
         }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -257,13 +257,19 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.TRUE;
                         defaultValue = "TODO"),
                 @Parameter(
                         name = "client.bootstrap.nodelay",
-                        description = "Http client no delay.",
+                        description = " This is mapped to TCP_NODELAY socket option which allows the network to " +
+                                "bypass Nagle Delays by disabling Nagle's algorithm, and sending the data " +
+                                "as soon as it's available\n. " +
+                                "Setting this parameter to 'true' forces a socket to send the data in its buffer, " +
+                                "whatever the packet size. \n" ,
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "true"),
                 @Parameter(
                         name = "client.bootstrap.keepalive",
-                        description = "Http client keep alive.",
+                        description = "This parameter defines whether the tcp connection should remain open for " +
+                                "multiple HTTP requests/responses. If this is set to 'false', HTTP connections will " +
+                                "be closed after each request.",
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "true"),
@@ -306,20 +312,20 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.TRUE;
                         optional = true,
                         defaultValue = "0"),
                 @Parameter(
-                        name = "max.active.connections.per.pool",
+                        name = "max.pool.active.connections",
                         description = "Maximum possible number of active connection per pool for the client.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "-1"),
                 @Parameter(
-                        name = "min.idle.connections.per.pool",
+                        name = "min.pool.idle.connections",
                         description = "Minimum allowed number of idle connections that can be existed in a pool of " +
                                 "the client.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "0"),
                 @Parameter(
-                        name = "max.idle.connections.per.pool",
+                        name = "max.pool.idle.connections",
                         description = "Maximum number of idle connections that can be existed in a pool of the " +
                                 "client.",
                         type = {DataType.INT},

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/HttpSink.java
@@ -340,7 +340,7 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.TRUE;
                         defaultValue = "300000ms"),
                 @Parameter(
                         name = "time.between.eviction.runs",
-                        description = "Time between two eviction operations (in miliseconds) on the connection pool",
+                        description = "Time between two eviction operations (in milliseconds) on the connection pool.",
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = "30000ms"),
@@ -373,10 +373,10 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.TRUE;
                         description = "Action which should be taken when the maximum number of active connections " +
                                 "are being used. This action is indicated as an integer. Possible action are as " +
                                 "following.\n" +
-                                "0 - Fail the request when pool is exhausted\n" +
-                                "1 - Block the request when pool is exhausted, until a connection return to the " +
-                                "pool\n" +
-                                "2 - Grow the connection pool size when it's exhausted",
+                                "0 - Fail the request when pool is exhausted.\n" +
+                                "1 - Block the request when pool is exhausted, until a connection returns to the " +
+                                "pool.\n" +
+                                "2 - Grow the connection pool size when it's exhausted.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "1 (Block when exhausted)"),

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/util/HttpSinkUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/sink/util/HttpSinkUtil.java
@@ -42,18 +42,9 @@ import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_BOOTST
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_BOOTSTRAP_SENDBUFFERSIZE;
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_BOOTSTRAP_SOCKET_REUSE;
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_BOOTSTRAP_SOCKET_TIMEOUT;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_CONNECTION_POOL_COUNT;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_MAX_ACTIVE_CONNECTIONS_PER_POOL;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_MAX_IDLE_CONNECTIONS_PER_POOL;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_MIN_EVICTION_IDLE_TIME;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.CLIENT_MIN_IDLE_CONNECTIONS_PER_POOL;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.EVENT_GROUP_EXECUTOR_THREAD_SIZE;
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.HTTP_TRACE_LOG_ENABLED;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.LATENCY_METRICS_ENABLED;
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.LOG_TRACE_ENABLE_DEFAULT_VALUE;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.MAX_WAIT_FOR_TRP_CLIENT_CONNECTION_POOL;
 import static org.wso2.extension.siddhi.io.http.util.HttpConstants.PARAMETER_SEPARATOR;
-import static org.wso2.extension.siddhi.io.http.util.HttpConstants.SENDER_THREAD_COUNT;
 import static org.wso2.extension.siddhi.io.http.util.HttpIoUtil.populateParameterMap;
 
 /**
@@ -293,14 +284,6 @@ public class HttpSinkUtil {
      */
     private static Map<String, TrpPropertyTypes> trpPropertyTypeMap() {
         Map<String, TrpPropertyTypes> trpPropertyTypes = new HashMap<>();
-        trpPropertyTypes.put(CLIENT_CONNECTION_POOL_COUNT, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(CLIENT_MAX_ACTIVE_CONNECTIONS_PER_POOL, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(CLIENT_MIN_IDLE_CONNECTIONS_PER_POOL, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(CLIENT_MAX_IDLE_CONNECTIONS_PER_POOL, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(CLIENT_MIN_EVICTION_IDLE_TIME, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(SENDER_THREAD_COUNT, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(EVENT_GROUP_EXECUTOR_THREAD_SIZE, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(MAX_WAIT_FOR_TRP_CLIENT_CONNECTION_POOL, TrpPropertyTypes.INTEGER);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_NODELAY, TrpPropertyTypes.BOOLEAN);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_KEEPALIVE, TrpPropertyTypes.BOOLEAN);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_SENDBUFFERSIZE, TrpPropertyTypes.INTEGER);
@@ -308,7 +291,6 @@ public class HttpSinkUtil {
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_CONNECT_TIMEOUT, TrpPropertyTypes.INTEGER);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_SOCKET_REUSE, TrpPropertyTypes.BOOLEAN);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_SOCKET_TIMEOUT, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(LATENCY_METRICS_ENABLED, TrpPropertyTypes.BOOLEAN);
         return trpPropertyTypes;
     }
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/source/HttpResponseMessageListener.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/source/HttpResponseMessageListener.java
@@ -21,12 +21,14 @@ package org.wso2.extension.siddhi.io.http.source;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.extension.siddhi.io.http.sink.HttpSink;
 import org.wso2.extension.siddhi.io.http.util.HTTPSourceRegistry;
 import org.wso2.extension.siddhi.io.http.util.HttpConstants;
 import org.wso2.extension.siddhi.io.http.util.ResponseSourceId;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
@@ -47,9 +49,11 @@ public class HttpResponseMessageListener implements HttpConnectorListener {
     private int tryCount;
     private String authType;
     private boolean isBlockingIO;
+    private HttpSink sink;
 
-    public HttpResponseMessageListener(Map<String, Object> trpProperties, String sinkId, boolean isDownloadEnabled,
-                                       CountDownLatch latch, int tryCount, String authType, boolean isBlockingIO) {
+    public HttpResponseMessageListener(HttpSink sink, Map<String, Object> trpProperties, String sinkId,
+                                       boolean isDownloadEnabled, CountDownLatch latch, int tryCount, String authType,
+                                       boolean isBlockingIO) {
         this.trpProperties = trpProperties;
         this.isDownloadEnabled = isDownloadEnabled;
         this.sinkId = sinkId;
@@ -57,6 +61,7 @@ public class HttpResponseMessageListener implements HttpConnectorListener {
         this.tryCount = tryCount;
         this.authType = authType;
         this.isBlockingIO = isBlockingIO;
+        this.sink = sink;
     }
 
     @Override
@@ -85,6 +90,10 @@ public class HttpResponseMessageListener implements HttpConnectorListener {
 
     @Override
     public void onError(Throwable throwable) {
+        if (throwable instanceof IOException) {
+            sink.initClientConnector(null);
+        }
+
         HttpResponseSource source = HTTPSourceRegistry.getResponseSource(sinkId, HttpConstants.DEFAULT_HTTP_ERROR_CODE);
         if (source != null) {
             responseConnectorListener = source.getConnectorListener();

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -175,14 +175,7 @@ public class HttpConstants {
     public static final String SERVER_BOOTSTRAP_SOCKET_BACKLOG_PARAM = "server.bootstrap.socket.backlog";
 
     //http source transport properties
-    public static final String CLIENT_CONNECTION_POOL_COUNT = "client.connection.pool.count";
-    public static final String CLIENT_MAX_ACTIVE_CONNECTIONS_PER_POOL = "client.max.active.connections.per.pool";
-    public static final String CLIENT_MIN_IDLE_CONNECTIONS_PER_POOL = "client.min.idle.connections.per.pool";
-    public static final String CLIENT_MAX_IDLE_CONNECTIONS_PER_POOL = "client.max.idle.connections.per.pool";
-    public static final String CLIENT_MIN_EVICTION_IDLE_TIME = "client.min.eviction.idle.time";
-    public static final String SENDER_THREAD_COUNT = "sender.thread.count";
-    public static final String EVENT_GROUP_EXECUTOR_THREAD_SIZE = "event.group.executor.thread.size";
-    public static final String MAX_WAIT_FOR_TRP_CLIENT_CONNECTION_POOL = "max.wait.for.trp.client.connection.pool";
+
     public static final String CLIENT_BOOTSTRAP_NODELAY = "client.bootstrap.nodelay";
     public static final String CLIENT_BOOTSTRAP_KEEPALIVE = "client.bootstrap.keepalive";
     public static final String CLIENT_BOOTSTRAP_SENDBUFFERSIZE = "client.bootstrap.sendbuffersize";
@@ -238,5 +231,27 @@ public class HttpConstants {
     public static final String ACCESS_TOKEN = "access_token";
     public static final String REFRESH_TOKEN = "refresh_token";
     public static final String BLOCKING_IO = "blocking.io";
+
+    //pool configurations
+    public static final String CONNECTION_POOL_COUNT = "connection.pool.count";
+    public static final String DEFAULT_CONNECTION_POOL_COUNT = "0";
+    public static final String MAX_ACTIVE_CONNECTIONS_PER_POOL = "max.active.connections.per.pool";
+    public static final String DEFAULT_MAX_ACTIVE_CONNECTIONS_PER_POOL = "-1"; // unlimited
+    public static final String MIN_IDLE_CONNECTIONS_PER_POOL = "min.idle.connections.per.pool";
+    public static final String DEFAULT_MIN_IDLE_CONNECTIONS_PER_POOL = "0";
+    public static final String MAX_IDLE_CONNECTIONS_PER_POOL = "max.idle.connections.per.pool";
+    public static final String DEFAULT_MAX_IDLE_CONNECTIONS_PER_POOL = "100";
+    public static final String MIN_EVICTABLE_IDLE_TIME = "min.evictable.idle.time";
+    public static final String DEFAULT_MIN_EVICTABLE_IDLE_TIME = "300000";
+    public static final String TIME_BETWEEN_EVICTION_RUNS = "time.between.eviction.runs";
+    public static final String DEFAULT_TIME_BETWEEN_EVICTION_RUNS = "30000";
+    public static final String TEST_ON_BORROW = "test.on.borrow";
+    public static final String DEFAULT_TEST_ON_BORROW = "true";
+    public static final String TEST_WHILE_IDLE = "test.while.idle";
+    public static final String DEFAULT_TEST_WHILE_IDLE = "true";
+    public static final String EXHAUSTED_ACTION = "exhausted.action";
+    public static final String DEFAULT_EXHAUSTED_ACTION = "1"; // block when exhausted
+    public static final String MAX_WAIT_TIME = "max.wait.time";
+    public static final String DEFAULT_MAX_WAIT_TIME = "60000";
     public static final String HOSTNAME_VERIFICATION_ENABLED = "hostname.verification.enabled";
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/http/util/HttpConstants.java
@@ -235,11 +235,11 @@ public class HttpConstants {
     //pool configurations
     public static final String CONNECTION_POOL_COUNT = "connection.pool.count";
     public static final String DEFAULT_CONNECTION_POOL_COUNT = "0";
-    public static final String MAX_ACTIVE_CONNECTIONS_PER_POOL = "max.active.connections.per.pool";
+    public static final String MAX_ACTIVE_CONNECTIONS_PER_POOL = "max.pool.active.connections";
     public static final String DEFAULT_MAX_ACTIVE_CONNECTIONS_PER_POOL = "-1"; // unlimited
-    public static final String MIN_IDLE_CONNECTIONS_PER_POOL = "min.idle.connections.per.pool";
+    public static final String MIN_IDLE_CONNECTIONS_PER_POOL = "min.pool.idle.connections";
     public static final String DEFAULT_MIN_IDLE_CONNECTIONS_PER_POOL = "0";
-    public static final String MAX_IDLE_CONNECTIONS_PER_POOL = "max.idle.connections.per.pool";
+    public static final String MAX_IDLE_CONNECTIONS_PER_POOL = "max.pool.idle.connections";
     public static final String DEFAULT_MAX_IDLE_CONNECTIONS_PER_POOL = "100";
     public static final String MIN_EVICTABLE_IDLE_TIME = "min.evictable.idle.time";
     public static final String DEFAULT_MIN_EVICTABLE_IDLE_TIME = "300000";

--- a/component/src/test/java/org/wso2/extension/siddhi/io/http/sink/util/HttpServerListener.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/http/sink/util/HttpServerListener.java
@@ -76,5 +76,4 @@ public class HttpServerListener implements HttpHandler {
     public boolean isMessageArrive() {
         return isEventArrived.get();
     }
-    
 }

--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -1,4 +1,4 @@
-# API Docs - v1.2.1
+# API Docs - v1.2.2-SNAPSHOT
 
 ## Sink
 
@@ -8,7 +8,7 @@
 
 <span id="syntax" class="md-typeset" style="display: block; font-weight: bold;">Syntax</span>
 ```
-@sink(type="http", publisher.url="<STRING>", basic.auth.username="<STRING>", basic.auth.password="<STRING>", https.truststore.file="<STRING>", https.truststore.password="<STRING>", headers="<STRING>", method="<STRING>", socket.idle.timeout="<INT>", chunk.disabled="<BOOL>", ssl.protocol="<STRING>", parameters="<STRING>", ciphers="<STRING>", ssl.enabled.protocols="<STRING>", client.enable.session.creation="<STRING>", follow.redirect="<BOOL>", max.redirect.count="<INT>", tls.store.type="<STRING>", proxy.host="<STRING>", proxy.port="<STRING>", proxy.username="<STRING>", proxy.password="<STRING>", client.bootstrap.configuration="<STRING>", client.bootstrap.nodelay="<BOOL>", client.bootstrap.keepalive="<BOOL>", client.bootstrap.sendbuffersize="<INT>", client.bootstrap.recievebuffersize="<INT>", client.bootstrap.connect.timeout="<INT>", client.bootstrap.socket.reuse="<BOOL>", client.bootstrap.socket.timeout="<STRING>", client.threadpool.configurations="<STRING>", client.connection.pool.count="<INT>", client.max.active.connections.per.pool="<INT>", client.min.idle.connections.per.pool="<INT>", client.max.idle.connections.per.pool="<INT>", client.min.eviction.idle.time="<STRING>", sender.thread.count="<STRING>", event.group.executor.thread.size="<STRING>", max.wait.for.client.connection.pool="<STRING>", oauth.username="<STRING>", oauth.password="<STRING>", consumer.key="<STRING>", consumer.secret="<STRING>", refresh.token="<STRING>", token.url="<STRING>", @map(...)))
+@sink(type="http", publisher.url="<STRING>", basic.auth.username="<STRING>", basic.auth.password="<STRING>", https.truststore.file="<STRING>", https.truststore.password="<STRING>", headers="<STRING>", method="<STRING>", socket.idle.timeout="<INT>", chunk.disabled="<BOOL>", ssl.protocol="<STRING>", parameters="<STRING>", ciphers="<STRING>", ssl.enabled.protocols="<STRING>", client.enable.session.creation="<STRING>", follow.redirect="<BOOL>", max.redirect.count="<INT>", tls.store.type="<STRING>", proxy.host="<STRING>", proxy.port="<STRING>", proxy.username="<STRING>", proxy.password="<STRING>", client.bootstrap.configuration="<STRING>", client.bootstrap.nodelay="<BOOL>", client.bootstrap.keepalive="<BOOL>", client.bootstrap.sendbuffersize="<INT>", client.bootstrap.recievebuffersize="<INT>", client.bootstrap.connect.timeout="<INT>", client.bootstrap.socket.reuse="<BOOL>", client.bootstrap.socket.timeout="<STRING>", connection.pool.count="<INT>", max.active.connections.per.pool="<INT>", min.idle.connections.per.pool="<INT>", max.idle.connections.per.pool="<INT>", min.evictable.idle.time="<STRING>", time.between.eviction.runs="<STRING>", max.wait.time="<STRING>", test.on.borrow="<BOOL>", test.while.idle="<BOOL>", exhausted.action="<INT>", oauth.username="<STRING>", oauth.password="<STRING>", consumer.key="<STRING>", consumer.secret="<STRING>", refresh.token="<STRING>", @map(...)))
 ```
 
 <span id="query-parameters" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">QUERY PARAMETERS</span>
@@ -254,81 +254,89 @@
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.threadpool.configurations</td>
-        <td style="vertical-align: top; word-wrap: break-word">Thread pool configuration. Expected format of these parameters is as follows: "'client.connection.pool.count:xxx','client.max.active.connections.per.pool:xxx'"</td>
-        <td style="vertical-align: top">TODO</td>
-        <td style="vertical-align: top">STRING</td>
-        <td style="vertical-align: top">Yes</td>
-        <td style="vertical-align: top">No</td>
-    </tr>
-    <tr>
-        <td style="vertical-align: top">client.connection.pool.count</td>
-        <td style="vertical-align: top; word-wrap: break-word">Connection pool count.</td>
+        <td style="vertical-align: top">connection.pool.count</td>
+        <td style="vertical-align: top; word-wrap: break-word">Number of connection pools that need to be created for the particular client.</td>
         <td style="vertical-align: top">0</td>
         <td style="vertical-align: top">INT</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.max.active.connections.per.pool</td>
-        <td style="vertical-align: top; word-wrap: break-word">Active connections per pool.</td>
+        <td style="vertical-align: top">max.active.connections.per.pool</td>
+        <td style="vertical-align: top; word-wrap: break-word">Maximum possible number of active connection per pool for the client.</td>
         <td style="vertical-align: top">-1</td>
         <td style="vertical-align: top">INT</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.min.idle.connections.per.pool</td>
-        <td style="vertical-align: top; word-wrap: break-word">Minimum ideal connection per pool.</td>
+        <td style="vertical-align: top">min.idle.connections.per.pool</td>
+        <td style="vertical-align: top; word-wrap: break-word">Minimum allowed number of idle connections that can be existed in a pool of the client.</td>
         <td style="vertical-align: top">0</td>
         <td style="vertical-align: top">INT</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.max.idle.connections.per.pool</td>
-        <td style="vertical-align: top; word-wrap: break-word">Maximum ideal connection per pool.</td>
+        <td style="vertical-align: top">max.idle.connections.per.pool</td>
+        <td style="vertical-align: top; word-wrap: break-word">Maximum number of idle connections that can be existed in a pool of the client.</td>
         <td style="vertical-align: top">100</td>
         <td style="vertical-align: top">INT</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.min.eviction.idle.time</td>
-        <td style="vertical-align: top; word-wrap: break-word">Minimum eviction idle time.</td>
-        <td style="vertical-align: top">5 * 60 * 1000</td>
+        <td style="vertical-align: top">min.evictable.idle.time</td>
+        <td style="vertical-align: top; word-wrap: break-word">Minimum amount of time (in milliseconds) a connection may sit idle in the pool before it is eligible for eviction.</td>
+        <td style="vertical-align: top">300000ms</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">sender.thread.count</td>
-        <td style="vertical-align: top; word-wrap: break-word">Http sender thread count.</td>
-        <td style="vertical-align: top">20</td>
+        <td style="vertical-align: top">time.between.eviction.runs</td>
+        <td style="vertical-align: top; word-wrap: break-word">Time between two eviction operations (in miliseconds) on the connection pool</td>
+        <td style="vertical-align: top">30000ms</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">event.group.executor.thread.size</td>
-        <td style="vertical-align: top; word-wrap: break-word">Event group executor thread size.</td>
-        <td style="vertical-align: top">15</td>
-        <td style="vertical-align: top">STRING</td>
-        <td style="vertical-align: top">Yes</td>
-        <td style="vertical-align: top">No</td>
-    </tr>
-    <tr>
-        <td style="vertical-align: top">max.wait.for.client.connection.pool</td>
-        <td style="vertical-align: top; word-wrap: break-word">Maximum wait for client connection pool.</td>
+        <td style="vertical-align: top">max.wait.time</td>
+        <td style="vertical-align: top; word-wrap: break-word">The maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned.</td>
         <td style="vertical-align: top">60000</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
+        <td style="vertical-align: top">test.on.borrow</td>
+        <td style="vertical-align: top; word-wrap: break-word">The indication of whether objects will be validated before being borrowed from the pool. If the object validation is failed, it will be dropped from the pool, and will attempt to borrow another.</td>
+        <td style="vertical-align: top">true</td>
+        <td style="vertical-align: top">BOOL</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top">test.while.idle</td>
+        <td style="vertical-align: top; word-wrap: break-word">The indication of whether objects will be validated by the idle object evictor (if any). If the object validation is failed, it will be dropped from the pool.</td>
+        <td style="vertical-align: top">true</td>
+        <td style="vertical-align: top">BOOL</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top">exhausted.action</td>
+        <td style="vertical-align: top; word-wrap: break-word">Action which should be taken when the maximum number of active connections are being used. This action is indicated as an integer. Possible action are as following.<br>0 - Fail the request when pool is exhausted<br>1 - Block the request when pool is exhausted, until a connection return to the pool<br>2 - Grow the connection pool size when it's exhausted</td>
+        <td style="vertical-align: top">1 (Block when exhausted)</td>
+        <td style="vertical-align: top">INT</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+    <tr>
         <td style="vertical-align: top">oauth.username</td>
         <td style="vertical-align: top; word-wrap: break-word">The username to be included in the authentication header of the oauth authentication enabled events. It is required to specify both username and password to enable oauth authentication. If one of the parameter is not given by user then an error is logged in the CLI. It is only applicable for for Oauth requests </td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -336,7 +344,7 @@
     <tr>
         <td style="vertical-align: top">oauth.password</td>
         <td style="vertical-align: top; word-wrap: break-word">The password to be included in the authentication header of the oauth authentication enabled events. It is required to specify both username and password to enable oauth authentication. If one of the parameter is not given by user then an error is logged in the CLI. It is only applicable for for Oauth requests </td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -344,7 +352,7 @@
     <tr>
         <td style="vertical-align: top">consumer.key</td>
         <td style="vertical-align: top; word-wrap: break-word">consumer key for the Http request. It is only applicable for for Oauth requests</td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -352,7 +360,7 @@
     <tr>
         <td style="vertical-align: top">consumer.secret</td>
         <td style="vertical-align: top; word-wrap: break-word">consumer secret for the Http request. It is only applicable for for Oauth requests</td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -360,15 +368,7 @@
     <tr>
         <td style="vertical-align: top">refresh.token</td>
         <td style="vertical-align: top; word-wrap: break-word">refresh token for the Http request. It is only applicable for for Oauth requests</td>
-        <td style="vertical-align: top"> </td>
-        <td style="vertical-align: top">STRING</td>
-        <td style="vertical-align: top">Yes</td>
-        <td style="vertical-align: top">No</td>
-    </tr>
-    <tr>
-        <td style="vertical-align: top">token.url</td>
-        <td style="vertical-align: top; word-wrap: break-word">token url for generate a new access token. It is only applicable for for Oauth requests</td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>


### PR DESCRIPTION
## Purpose
> Introduce properties for pool configurations in http sink.

## Goals
> The following properties were introduced to http sink for configuring connection pools.

| Property | Description | Default Value | 
| ----------- | -------------- | ----------------- |
| connection.pool.count | Number of connection pools that need to be created for the particular client. | 0 | 
| max.pool.active.connections | Maximum possible number of active connection per pool for the client. | -1 (Unlimited) | 
| min.pool.idle.connections | Minimum allowed number of idle connections that can be existed in a pool of the client.  | 0 |
| max.pool.idle.connections | Maximum number of idle connections that can be existed in a pool of the client. | 100 | 
| min.evictable.idle.time | Minimum amount of time (in milliseconds) a connection may sit idle in the pool before it is eligible for eviction. | 300000 ms | 
| time.between.eviction.runs | Time between two eviction operations (in milliseconds) on the connection pool. | 30000 ms | 
| max.wait.time | The maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned. | 60000 ms | 
| test.on.borrow | The indication of whether objects will be validated before being borrowed from the pool. If the object validation is failed, it will be dropped from the pool, and will attempt to borrow another. | true | 
| test.while.idle | The indication of whether objects will be validated by the idle object evictor (if any). If the object validation is failed, it will be dropped from the pool. | true | 
| exhausted.action | Action which should be taken when the maximum number of active connections are being used. This action is indicated as an integer. Possible action are as following.<br>0 - Fail the request when pool is exhausted<br>1 - Block the request when pool is exhausted, until a connection returns to the pool.<br>2 - Grow the connection pool size when it's exhausted. | 1 (Block when exhausted) | 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
