### PR TITLE
Introduce properties for pool configurations

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/sink/HttpRequestSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/HttpRequestSink.java
@@ -728,7 +728,7 @@ public class HttpRequestSink extends HttpSink {
         HttpResponseFuture httpResponseFuture = clientConnector.send(cMessage);
         HttpResponseMessageListener httpListener;
         CountDownLatch latch = isBlockingIO ? responseLatch : new CountDownLatch(1);
-        httpListener = new HttpResponseMessageListener(getTrpProperties(dynamicOptions), sinkId,
+        httpListener = new HttpResponseMessageListener(this, getTrpProperties(dynamicOptions), sinkId,
                 isDownloadEnabled, latch, tryCount, authType, isBlockingIO);
         httpResponseFuture.setHttpConnectorListener(httpListener);
 

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
@@ -261,13 +261,19 @@ import static io.siddhi.extension.io.http.util.HttpConstants.TRUE;
                         defaultValue = "TODO"),
                 @Parameter(
                         name = "client.bootstrap.nodelay",
-                        description = "Http client no delay.",
+                        description = " This is mapped to TCP_NODELAY socket option which allows the network to " +
+                                "bypass Nagle Delays by disabling Nagle's algorithm, and sending the data " +
+                                "as soon as it's available\n. " +
+                                "Setting this parameter to 'true' forces a socket to send the data in its buffer, " +
+                                "whatever the packet size. \n" ,
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "true"),
                 @Parameter(
                         name = "client.bootstrap.keepalive",
-                        description = "Http client keep alive.",
+                        description = "This parameter defines whether the tcp connection should remain open for " +
+                                "multiple HTTP requests/responses. If this is set to 'false', HTTP connections will " +
+                                "be closed after each request.",
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "true"),
@@ -310,20 +316,20 @@ import static io.siddhi.extension.io.http.util.HttpConstants.TRUE;
                         optional = true,
                         defaultValue = "0"),
                 @Parameter(
-                        name = "max.active.connections.per.pool",
+                        name = "max.pool.active.connections",
                         description = "Maximum possible number of active connection per pool for the client.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "-1"),
                 @Parameter(
-                        name = "min.idle.connections.per.pool",
+                        name = "min.pool.idle.connections",
                         description = "Minimum allowed number of idle connections that can be existed in a pool of " +
                                 "the client.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "0"),
                 @Parameter(
-                        name = "max.idle.connections.per.pool",
+                        name = "max.pool.idle.connections",
                         description = "Maximum number of idle connections that can be existed in a pool of the " +
                                 "client.",
                         type = {DataType.INT},

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
@@ -344,7 +344,7 @@ import static io.siddhi.extension.io.http.util.HttpConstants.TRUE;
                         defaultValue = "300000ms"),
                 @Parameter(
                         name = "time.between.eviction.runs",
-                        description = "Time between two eviction operations (in miliseconds) on the connection pool",
+                        description = "Time between two eviction operations (in milliseconds) on the connection pool.",
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = "30000ms"),
@@ -377,10 +377,10 @@ import static io.siddhi.extension.io.http.util.HttpConstants.TRUE;
                         description = "Action which should be taken when the maximum number of active connections " +
                                 "are being used. This action is indicated as an integer. Possible action are as " +
                                 "following.\n" +
-                                "0 - Fail the request when pool is exhausted\n" +
-                                "1 - Block the request when pool is exhausted, until a connection return to the " +
-                                "pool\n" +
-                                "2 - Grow the connection pool size when it's exhausted",
+                                "0 - Fail the request when pool is exhausted.\n" +
+                                "1 - Block the request when pool is exhausted, until a connection returns to the " +
+                                "pool.\n" +
+                                "2 - Grow the connection pool size when it's exhausted.",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "1 (Block when exhausted)"),

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
@@ -290,14 +290,6 @@ public class HttpSinkUtil {
      */
     private static Map<String, TrpPropertyTypes> trpPropertyTypeMap() {
         Map<String, TrpPropertyTypes> trpPropertyTypes = new HashMap<>();
-        trpPropertyTypes.put(CLIENT_CONNECTION_POOL_COUNT, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(CLIENT_MAX_ACTIVE_CONNECTIONS_PER_POOL, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(CLIENT_MIN_IDLE_CONNECTIONS_PER_POOL, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(CLIENT_MAX_IDLE_CONNECTIONS_PER_POOL, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(CLIENT_MIN_EVICTION_IDLE_TIME, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(SENDER_THREAD_COUNT, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(EVENT_GROUP_EXECUTOR_THREAD_SIZE, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(MAX_WAIT_FOR_TRP_CLIENT_CONNECTION_POOL, TrpPropertyTypes.INTEGER);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_NODELAY, TrpPropertyTypes.BOOLEAN);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_KEEPALIVE, TrpPropertyTypes.BOOLEAN);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_SENDBUFFERSIZE, TrpPropertyTypes.INTEGER);
@@ -305,7 +297,6 @@ public class HttpSinkUtil {
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_CONNECT_TIMEOUT, TrpPropertyTypes.INTEGER);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_SOCKET_REUSE, TrpPropertyTypes.BOOLEAN);
         trpPropertyTypes.put(CLIENT_BOOTSTRAP_SOCKET_TIMEOUT, TrpPropertyTypes.INTEGER);
-        trpPropertyTypes.put(LATENCY_METRICS_ENABLED, TrpPropertyTypes.BOOLEAN);
         return trpPropertyTypes;
     }
 }

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
@@ -42,18 +42,9 @@ import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_BOOTSTRAP_RE
 import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_BOOTSTRAP_SENDBUFFERSIZE;
 import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_BOOTSTRAP_SOCKET_REUSE;
 import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_BOOTSTRAP_SOCKET_TIMEOUT;
-import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_CONNECTION_POOL_COUNT;
-import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_MAX_ACTIVE_CONNECTIONS_PER_POOL;
-import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_MAX_IDLE_CONNECTIONS_PER_POOL;
-import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_MIN_EVICTION_IDLE_TIME;
-import static io.siddhi.extension.io.http.util.HttpConstants.CLIENT_MIN_IDLE_CONNECTIONS_PER_POOL;
-import static io.siddhi.extension.io.http.util.HttpConstants.EVENT_GROUP_EXECUTOR_THREAD_SIZE;
 import static io.siddhi.extension.io.http.util.HttpConstants.HTTP_TRACE_LOG_ENABLED;
-import static io.siddhi.extension.io.http.util.HttpConstants.LATENCY_METRICS_ENABLED;
 import static io.siddhi.extension.io.http.util.HttpConstants.LOG_TRACE_ENABLE_DEFAULT_VALUE;
-import static io.siddhi.extension.io.http.util.HttpConstants.MAX_WAIT_FOR_TRP_CLIENT_CONNECTION_POOL;
 import static io.siddhi.extension.io.http.util.HttpConstants.PARAMETER_SEPARATOR;
-import static io.siddhi.extension.io.http.util.HttpConstants.SENDER_THREAD_COUNT;
 import static io.siddhi.extension.io.http.util.HttpIoUtil.populateParameterMap;
 
 /**

--- a/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
@@ -164,14 +164,7 @@ public class HttpConstants {
     public static final String SERVER_BOOTSTRAP_SOCKET_TIMEOUT_PARAM = "server.bootstrap.socket.timeout";
     public static final String SERVER_BOOTSTRAP_SOCKET_BACKLOG_PARAM = "server.bootstrap.socket.backlog";
     //http source transport properties
-    public static final String CLIENT_CONNECTION_POOL_COUNT = "client.connection.pool.count";
-    public static final String CLIENT_MAX_ACTIVE_CONNECTIONS_PER_POOL = "client.max.active.connections.per.pool";
-    public static final String CLIENT_MIN_IDLE_CONNECTIONS_PER_POOL = "client.min.idle.connections.per.pool";
-    public static final String CLIENT_MAX_IDLE_CONNECTIONS_PER_POOL = "client.max.idle.connections.per.pool";
-    public static final String CLIENT_MIN_EVICTION_IDLE_TIME = "client.min.eviction.idle.time";
-    public static final String SENDER_THREAD_COUNT = "sender.thread.count";
-    public static final String EVENT_GROUP_EXECUTOR_THREAD_SIZE = "event.group.executor.thread.size";
-    public static final String MAX_WAIT_FOR_TRP_CLIENT_CONNECTION_POOL = "max.wait.for.trp.client.connection.pool";
+
     public static final String CLIENT_BOOTSTRAP_NODELAY = "client.bootstrap.nodelay";
     public static final String CLIENT_BOOTSTRAP_KEEPALIVE = "client.bootstrap.keepalive";
     public static final String CLIENT_BOOTSTRAP_SENDBUFFERSIZE = "client.bootstrap.sendbuffersize";
@@ -224,5 +217,27 @@ public class HttpConstants {
     public static final String ACCESS_TOKEN = "access_token";
     public static final String REFRESH_TOKEN = "refresh_token";
     public static final String BLOCKING_IO = "blocking.io";
+
+    //pool configurations
+    public static final String CONNECTION_POOL_COUNT = "connection.pool.count";
+    public static final String DEFAULT_CONNECTION_POOL_COUNT = "0";
+    public static final String MAX_ACTIVE_CONNECTIONS_PER_POOL = "max.active.connections.per.pool";
+    public static final String DEFAULT_MAX_ACTIVE_CONNECTIONS_PER_POOL = "-1"; // unlimited
+    public static final String MIN_IDLE_CONNECTIONS_PER_POOL = "min.idle.connections.per.pool";
+    public static final String DEFAULT_MIN_IDLE_CONNECTIONS_PER_POOL = "0";
+    public static final String MAX_IDLE_CONNECTIONS_PER_POOL = "max.idle.connections.per.pool";
+    public static final String DEFAULT_MAX_IDLE_CONNECTIONS_PER_POOL = "100";
+    public static final String MIN_EVICTABLE_IDLE_TIME = "min.evictable.idle.time";
+    public static final String DEFAULT_MIN_EVICTABLE_IDLE_TIME = "300000";
+    public static final String TIME_BETWEEN_EVICTION_RUNS = "time.between.eviction.runs";
+    public static final String DEFAULT_TIME_BETWEEN_EVICTION_RUNS = "30000";
+    public static final String TEST_ON_BORROW = "test.on.borrow";
+    public static final String DEFAULT_TEST_ON_BORROW = "true";
+    public static final String TEST_WHILE_IDLE = "test.while.idle";
+    public static final String DEFAULT_TEST_WHILE_IDLE = "true";
+    public static final String EXHAUSTED_ACTION = "exhausted.action";
+    public static final String DEFAULT_EXHAUSTED_ACTION = "1"; // block when exhausted
+    public static final String MAX_WAIT_TIME = "max.wait.time";
+    public static final String DEFAULT_MAX_WAIT_TIME = "60000";
     public static final String HOSTNAME_VERIFICATION_ENABLED = "hostname.verification.enabled";
 }

--- a/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
@@ -221,11 +221,11 @@ public class HttpConstants {
     //pool configurations
     public static final String CONNECTION_POOL_COUNT = "connection.pool.count";
     public static final String DEFAULT_CONNECTION_POOL_COUNT = "0";
-    public static final String MAX_ACTIVE_CONNECTIONS_PER_POOL = "max.active.connections.per.pool";
+    public static final String MAX_ACTIVE_CONNECTIONS_PER_POOL = "max.pool.active.connections";
     public static final String DEFAULT_MAX_ACTIVE_CONNECTIONS_PER_POOL = "-1"; // unlimited
-    public static final String MIN_IDLE_CONNECTIONS_PER_POOL = "min.idle.connections.per.pool";
+    public static final String MIN_IDLE_CONNECTIONS_PER_POOL = "min.pool.idle.connections";
     public static final String DEFAULT_MIN_IDLE_CONNECTIONS_PER_POOL = "0";
-    public static final String MAX_IDLE_CONNECTIONS_PER_POOL = "max.idle.connections.per.pool";
+    public static final String MAX_IDLE_CONNECTIONS_PER_POOL = "max.pool.idle.connections";
     public static final String DEFAULT_MAX_IDLE_CONNECTIONS_PER_POOL = "100";
     public static final String MIN_EVICTABLE_IDLE_TIME = "min.evictable.idle.time";
     public static final String DEFAULT_MIN_EVICTABLE_IDLE_TIME = "300000";

--- a/component/src/test/java/io/siddhi/extension/io/http/sink/util/HttpServerListener.java
+++ b/component/src/test/java/io/siddhi/extension/io/http/sink/util/HttpServerListener.java
@@ -76,5 +76,4 @@ public class HttpServerListener implements HttpHandler {
     public boolean isMessageArrive() {
         return isEventArrived.get();
     }
-
 }

--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -8,7 +8,11 @@
 
 <span id="syntax" class="md-typeset" style="display: block; font-weight: bold;">Syntax</span>
 ```
+<<<<<<< HEAD
 @sink(type="http", publisher.url="<STRING>", basic.auth.username="<STRING>", basic.auth.password="<STRING>", https.truststore.file="<STRING>", https.truststore.password="<STRING>", headers="<STRING>", method="<STRING>", socket.idle.timeout="<INT>", chunk.disabled="<BOOL>", ssl.protocol="<STRING>", parameters="<STRING>", ciphers="<STRING>", ssl.enabled.protocols="<STRING>", client.enable.session.creation="<STRING>", follow.redirect="<BOOL>", max.redirect.count="<INT>", tls.store.type="<STRING>", proxy.host="<STRING>", proxy.port="<STRING>", proxy.username="<STRING>", proxy.password="<STRING>", client.bootstrap.configuration="<STRING>", client.bootstrap.nodelay="<BOOL>", client.bootstrap.keepalive="<BOOL>", client.bootstrap.sendbuffersize="<INT>", client.bootstrap.recievebuffersize="<INT>", client.bootstrap.connect.timeout="<INT>", client.bootstrap.socket.reuse="<BOOL>", client.bootstrap.socket.timeout="<STRING>", client.threadpool.configurations="<STRING>", client.connection.pool.count="<INT>", client.max.active.connections.per.pool="<INT>", client.min.idle.connections.per.pool="<INT>", client.max.idle.connections.per.pool="<INT>", client.min.eviction.idle.time="<STRING>", sender.thread.count="<STRING>", event.group.executor.thread.size="<STRING>", max.wait.for.client.connection.pool="<STRING>", oauth.username="<STRING>", oauth.password="<STRING>", consumer.key="<STRING>", consumer.secret="<STRING>", refresh.token="<STRING>", token.url="<STRING>", hostname.verification.enabled="<BOOL>", @map(...)))
+=======
+@sink(type="http", publisher.url="<STRING>", basic.auth.username="<STRING>", basic.auth.password="<STRING>", https.truststore.file="<STRING>", https.truststore.password="<STRING>", headers="<STRING>", method="<STRING>", socket.idle.timeout="<INT>", chunk.disabled="<BOOL>", ssl.protocol="<STRING>", parameters="<STRING>", ciphers="<STRING>", ssl.enabled.protocols="<STRING>", client.enable.session.creation="<STRING>", follow.redirect="<BOOL>", max.redirect.count="<INT>", tls.store.type="<STRING>", proxy.host="<STRING>", proxy.port="<STRING>", proxy.username="<STRING>", proxy.password="<STRING>", client.bootstrap.configuration="<STRING>", client.bootstrap.nodelay="<BOOL>", client.bootstrap.keepalive="<BOOL>", client.bootstrap.sendbuffersize="<INT>", client.bootstrap.recievebuffersize="<INT>", client.bootstrap.connect.timeout="<INT>", client.bootstrap.socket.reuse="<BOOL>", client.bootstrap.socket.timeout="<STRING>", connection.pool.count="<INT>", max.active.connections.per.pool="<INT>", min.idle.connections.per.pool="<INT>", max.idle.connections.per.pool="<INT>", min.evictable.idle.time="<STRING>", time.between.eviction.runs="<STRING>", max.wait.time="<STRING>", test.on.borrow="<BOOL>", test.while.idle="<BOOL>", exhausted.action="<INT>", oauth.username="<STRING>", oauth.password="<STRING>", consumer.key="<STRING>", consumer.secret="<STRING>", refresh.token="<STRING>", @map(...)))
+>>>>>>> b3537c3... Introduce pool configuration parameters to HttpSink
 ```
 
 <span id="query-parameters" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">QUERY PARAMETERS</span>
@@ -254,81 +258,89 @@
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.threadpool.configurations</td>
-        <td style="vertical-align: top; word-wrap: break-word">Thread pool configuration. Expected format of these parameters is as follows: "'client.connection.pool.count:xxx','client.max.active.connections.per.pool:xxx'"</td>
-        <td style="vertical-align: top">TODO</td>
-        <td style="vertical-align: top">STRING</td>
-        <td style="vertical-align: top">Yes</td>
-        <td style="vertical-align: top">No</td>
-    </tr>
-    <tr>
-        <td style="vertical-align: top">client.connection.pool.count</td>
-        <td style="vertical-align: top; word-wrap: break-word">Connection pool count.</td>
+        <td style="vertical-align: top">connection.pool.count</td>
+        <td style="vertical-align: top; word-wrap: break-word">Number of connection pools that need to be created for the particular client.</td>
         <td style="vertical-align: top">0</td>
         <td style="vertical-align: top">INT</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.max.active.connections.per.pool</td>
-        <td style="vertical-align: top; word-wrap: break-word">Active connections per pool.</td>
+        <td style="vertical-align: top">max.active.connections.per.pool</td>
+        <td style="vertical-align: top; word-wrap: break-word">Maximum possible number of active connection per pool for the client.</td>
         <td style="vertical-align: top">-1</td>
         <td style="vertical-align: top">INT</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.min.idle.connections.per.pool</td>
-        <td style="vertical-align: top; word-wrap: break-word">Minimum ideal connection per pool.</td>
+        <td style="vertical-align: top">min.idle.connections.per.pool</td>
+        <td style="vertical-align: top; word-wrap: break-word">Minimum allowed number of idle connections that can be existed in a pool of the client.</td>
         <td style="vertical-align: top">0</td>
         <td style="vertical-align: top">INT</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.max.idle.connections.per.pool</td>
-        <td style="vertical-align: top; word-wrap: break-word">Maximum ideal connection per pool.</td>
+        <td style="vertical-align: top">max.idle.connections.per.pool</td>
+        <td style="vertical-align: top; word-wrap: break-word">Maximum number of idle connections that can be existed in a pool of the client.</td>
         <td style="vertical-align: top">100</td>
         <td style="vertical-align: top">INT</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">client.min.eviction.idle.time</td>
-        <td style="vertical-align: top; word-wrap: break-word">Minimum eviction idle time.</td>
-        <td style="vertical-align: top">5 * 60 * 1000</td>
+        <td style="vertical-align: top">min.evictable.idle.time</td>
+        <td style="vertical-align: top; word-wrap: break-word">Minimum amount of time (in milliseconds) a connection may sit idle in the pool before it is eligible for eviction.</td>
+        <td style="vertical-align: top">300000ms</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">sender.thread.count</td>
-        <td style="vertical-align: top; word-wrap: break-word">Http sender thread count.</td>
-        <td style="vertical-align: top">20</td>
+        <td style="vertical-align: top">time.between.eviction.runs</td>
+        <td style="vertical-align: top; word-wrap: break-word">Time between two eviction operations (in miliseconds) on the connection pool</td>
+        <td style="vertical-align: top">30000ms</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
-        <td style="vertical-align: top">event.group.executor.thread.size</td>
-        <td style="vertical-align: top; word-wrap: break-word">Event group executor thread size.</td>
-        <td style="vertical-align: top">15</td>
-        <td style="vertical-align: top">STRING</td>
-        <td style="vertical-align: top">Yes</td>
-        <td style="vertical-align: top">No</td>
-    </tr>
-    <tr>
-        <td style="vertical-align: top">max.wait.for.client.connection.pool</td>
-        <td style="vertical-align: top; word-wrap: break-word">Maximum wait for client connection pool.</td>
+        <td style="vertical-align: top">max.wait.time</td>
+        <td style="vertical-align: top; word-wrap: break-word">The maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned.</td>
         <td style="vertical-align: top">60000</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
     </tr>
     <tr>
+        <td style="vertical-align: top">test.on.borrow</td>
+        <td style="vertical-align: top; word-wrap: break-word">The indication of whether objects will be validated before being borrowed from the pool. If the object validation is failed, it will be dropped from the pool, and will attempt to borrow another.</td>
+        <td style="vertical-align: top">true</td>
+        <td style="vertical-align: top">BOOL</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top">test.while.idle</td>
+        <td style="vertical-align: top; word-wrap: break-word">The indication of whether objects will be validated by the idle object evictor (if any). If the object validation is failed, it will be dropped from the pool.</td>
+        <td style="vertical-align: top">true</td>
+        <td style="vertical-align: top">BOOL</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+    <tr>
+        <td style="vertical-align: top">exhausted.action</td>
+        <td style="vertical-align: top; word-wrap: break-word">Action which should be taken when the maximum number of active connections are being used. This action is indicated as an integer. Possible action are as following.<br>0 - Fail the request when pool is exhausted<br>1 - Block the request when pool is exhausted, until a connection return to the pool<br>2 - Grow the connection pool size when it's exhausted</td>
+        <td style="vertical-align: top">1 (Block when exhausted)</td>
+        <td style="vertical-align: top">INT</td>
+        <td style="vertical-align: top">Yes</td>
+        <td style="vertical-align: top">No</td>
+    </tr>
+    <tr>
         <td style="vertical-align: top">oauth.username</td>
         <td style="vertical-align: top; word-wrap: break-word">The username to be included in the authentication header of the oauth authentication enabled events. It is required to specify both username and password to enable oauth authentication. If one of the parameter is not given by user then an error is logged in the CLI. It is only applicable for for Oauth requests </td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -336,7 +348,7 @@
     <tr>
         <td style="vertical-align: top">oauth.password</td>
         <td style="vertical-align: top; word-wrap: break-word">The password to be included in the authentication header of the oauth authentication enabled events. It is required to specify both username and password to enable oauth authentication. If one of the parameter is not given by user then an error is logged in the CLI. It is only applicable for for Oauth requests </td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -344,7 +356,7 @@
     <tr>
         <td style="vertical-align: top">consumer.key</td>
         <td style="vertical-align: top; word-wrap: break-word">consumer key for the Http request. It is only applicable for for Oauth requests</td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -352,7 +364,7 @@
     <tr>
         <td style="vertical-align: top">consumer.secret</td>
         <td style="vertical-align: top; word-wrap: break-word">consumer secret for the Http request. It is only applicable for for Oauth requests</td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -360,15 +372,7 @@
     <tr>
         <td style="vertical-align: top">refresh.token</td>
         <td style="vertical-align: top; word-wrap: break-word">refresh token for the Http request. It is only applicable for for Oauth requests</td>
-        <td style="vertical-align: top"> </td>
-        <td style="vertical-align: top">STRING</td>
-        <td style="vertical-align: top">Yes</td>
-        <td style="vertical-align: top">No</td>
-    </tr>
-    <tr>
-        <td style="vertical-align: top">token.url</td>
-        <td style="vertical-align: top; word-wrap: break-word">token url for generate a new access token. It is only applicable for for Oauth requests</td>
-        <td style="vertical-align: top"> </td>
+        <td style="vertical-align: top">NONE</td>
         <td style="vertical-align: top">STRING</td>
         <td style="vertical-align: top">Yes</td>
         <td style="vertical-align: top">No</td>
@@ -834,11 +838,11 @@ define stream FooStream (payloadBody String, method string, headers string);
 ```
 @sink(type='http-request', sink.id='foo', publisher.url='http://localhost:8009/foo', @map(type='xml', @payload('{{payloadBody}}')))
 define stream FooStream (payloadBody String, method string, headers string);
-@source(type='http-response', sink.id='foo', http.status.code='2\\d+', 
+@source(type='http-response', sink.id='foo', http.status.code='2\\d+',
 @map(type='text', regex.A='((.|\n)*)', @attributes(headers='trp:headers', fileName='A[1]')))
 define stream responseStream2xx(fileName string, headers string);
 
-@source(type='http-response', sink.id='foo', http.status.code='4\\d+', 
+@source(type='http-response', sink.id='foo', http.status.code='4\\d+',
 @map(type='text', regex.A='((.|\n)*)', @attributes(errorMsg='A[1]')))
 define stream responseStream4xx(errorMsg string);
 ```
@@ -847,18 +851,18 @@ define stream responseStream4xx(errorMsg string);
 <span id="example-2" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 2</span>
 ```
 define stream FooStream (name String, id int, headers String, downloadPath string);
-@sink(type='http-request', 
+@sink(type='http-request',
 downloading.enabled='true',
 download.path='{{downloadPath}}',publisher.url='http://localhost:8005/files',
 method='GET', headers='{{headers}}',sink.id='download-sink',
-@map(type='json')) 
+@map(type='json'))
 define stream BarStream (name String, id int, headers String, downloadPath string);
 
-@source(type='http-response', sink.id='download-sink', http.status.code='2\\d+', 
+@source(type='http-response', sink.id='download-sink', http.status.code='2\\d+',
 @map(type='text', regex.A='((.|\n)*)', @attributes(headers='trp:headers', fileName='A[1]')))
 define stream responseStream2xx(fileName string, headers string);
 
-@source(type='http-response', sink.id='download-sink', http.status.code='4\\d+', 
+@source(type='http-response', sink.id='download-sink', http.status.code='4\\d+',
 @map(type='text', regex.A='((.|\n)*)', @attributes(errorMsg='A[1]')))
 define stream responseStream4xx(errorMsg string);
 ```
@@ -1754,17 +1758,17 @@ define stream FooStream (messageId string, symbol string, price float, volume lo
 <span id="examples" class="md-typeset" style="display: block; font-weight: bold;">Examples</span>
 <span id="example-1" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 1</span>
 ```
-@sink(type='http-request', 
+@sink(type='http-request',
 downloading.enabled='true',
 publisher.url='http://localhost:8005/registry/employee',
 method='POST', headers='{{headers}}',sink.id='employee-info',
-@map(type='json')) 
+@map(type='json'))
 define stream BarStream (name String, id int, headers String, downloadPath string);
 
 @source(type='http-response' , sink.id='employee-info', http.status.code='2\\d+',
-@map(type='text', regex.A='((.|\n)*)', @attributes(message='A[1]'))) 
+@map(type='text', regex.A='((.|\n)*)', @attributes(message='A[1]')))
 define stream responseStream2xx(message string);@source(type='http-response' , sink.id='employee-info', http.status.code='4\\d+' ,
-@map(type='text', regex.A='((.|\n)*)', @attributes(message='A[1]')))  
+@map(type='text', regex.A='((.|\n)*)', @attributes(message='A[1]')))
 define stream responseStream4xx(message string);
 ```
 <p style="word-wrap: break-word">In above example, the defined http-request sink will send a POST requests to the endpoint defined by 'publisher.url'.<br>Then for those requests, the source with the response code '2\\d+' and sink.id 'employee-info' will receive the responses with 2xx status codes. <br>The http-response source which has 'employee-info' as the 'sink.id' and '4\\d+' as the http.response.code will receive all the responses with 4xx status codes.<br>. Then the body of the response message will be extracted using text mapper and converted into siddhi events.<br>.</p>


### PR DESCRIPTION
## Purpose
Introduce properties for pool configurations in HTTP sink.

## Goals
The following properties were introduced to HTTP sink for configuring connection pools.

| Property | Description | Default Value | 
| ----------- | -------------- | ----------------- |
| connection.pool.count | Number of connection pools that need to be created for the particular client. | 0 | 
| max.pool.active.connections | Maximum possible number of active connection per pool for the client. | -1 (Unlimited) | 
| min.pool.idle.connections | Minimum allowed number of idle connections that can be existed in a pool of the client.  | 0 |
| max.pool.idle.connections | Maximum number of idle connections that can be existed in a pool of the client. | 100 | 
| min.evictable.idle.time | Minimum amount of time (in milliseconds) a connection may sit idle in the pool before it is eligible for eviction. | 300000 ms | 
| time.between.eviction.runs | Time between two eviction operations (in milliseconds) on the connection pool. | 30000 ms | 
| max.wait.time | The maximum number of milliseconds that the pool will wait (when there are no available connections) for a connection to be returned. | 60000 ms | 
| test.on.borrow | The indication of whether objects will be validated before being borrowed from the pool. If the object validation is failed, it will be dropped from the pool, and will attempt to borrow another. | true | 
| test.while.idle | The indication of whether objects will be validated by the idle object evictor (if any). If the object validation is failed, it will be dropped from the pool. | true | 
| exhausted.action | Action which should be taken when the maximum number of active connections are being used. This action is indicated as an integer. Possible action are as following.<br>0 - Fail the request when the pool is exhausted<br>1 - Block the request when the pool is exhausted, until a connection returns to the pool.<br>2 - Grow the connection pool size when it's exhausted. | 1 (Block when exhausted) | 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
