### PR TITLE
Fix empty check after String.valueOF()

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/source/HttpSourceListener.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/source/HttpSourceListener.java
@@ -113,9 +113,9 @@ public class HttpSourceListener {
         if (requestedTransportPropertyNames.length > 0) {      //cannot be null according to siddhi impl
             int i = 0;
             for (String property : requestedTransportPropertyNames) {
-                String value = String.valueOf(carbonMessage.getProperty(property));
-                if (value.trim().isEmpty()) {
-                    properties[i] = value;
+                Object value = carbonMessage.getProperty(property);
+                if (value != null) {
+                    properties[i] = String.valueOf(value);
                 }
                 i++;
             }


### PR DESCRIPTION
## Purpose
$subject as the String.valueoF() will return "null" string in the event value becomes null

## Documentation
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
