### PR TITLE
Improve HTTPCallResponse flow

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/sink/HttpServiceResponseSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/HttpServiceResponseSink.java
@@ -191,8 +191,8 @@ public class HttpServiceResponseSink extends Sink {
         List<Header> headersList = HttpSinkUtil.getHeaders(headers);
         String messageId = messageIdOption.getValue(dynamicOptions);
         String contentType = HttpSinkUtil.getContentType(mapType, headersList);
-        HTTPSourceRegistry.
-                getServiceSource(sourceId).handleCallback(messageId, (String) payload, headersList, contentType);
+        HTTPSourceRegistry.getInstance()
+                .getServiceSource(sourceId).handleCallback(messageId, (String) payload, headersList, contentType);
     }
 
     /**

--- a/component/src/main/java/io/siddhi/extension/io/http/source/HttpCallResponseSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/source/HttpCallResponseSource.java
@@ -184,13 +184,13 @@ public class HttpCallResponseSource extends Source {
                         shouldAllowStreamingResponses, sinkId, requestedTransportPropertyNames, siddhiAppName);
         this.httpConnectorRegistry.registerSourceListener(httpCallResponseSourceListener, sinkId, httpStatusCode);
 
-        HTTPSourceRegistry.registerCallResponseSource(sinkId, httpStatusCode, this);
+        HTTPSourceRegistry.getInstance().registerCallResponseSource(sinkId, this);
     }
 
     @Override
     public void disconnect() {
         this.httpConnectorRegistry.unregisterSourceListener(sinkId, httpStatusCode, siddhiAppName);
-        HTTPSourceRegistry.removeCallResponseSource(sinkId, httpStatusCode);
+        HTTPSourceRegistry.getInstance().removeCallResponseSource(sinkId, httpStatusCode);
     }
 
     @Override
@@ -209,5 +209,9 @@ public class HttpCallResponseSource extends Source {
 
     public HttpCallResponseConnectorListener getConnectorListener() {
         return httpCallResponseSourceListener;
+    }
+
+    public String getHttpStatusCode() {
+        return httpStatusCode;
     }
 }

--- a/component/src/main/java/io/siddhi/extension/io/http/source/HttpServiceSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/source/HttpServiceSource.java
@@ -383,7 +383,7 @@ public class HttpServiceSource extends HttpSource {
         this.httpConnectorRegistry.registerSourceListener(sourceEventListener, listenerUrl,
                 workerThread, isAuth, requestedTransportPropertyNames, sourceId, siddhiAppName);
 
-        HTTPSourceRegistry.registerServiceSource(sourceId, this);
+        HTTPSourceRegistry.getInstance().registerServiceSource(sourceId, this);
     }
 
     /**
@@ -394,7 +394,7 @@ public class HttpServiceSource extends HttpSource {
         this.httpConnectorRegistry.unregisterSourceListener(this.listenerUrl, siddhiAppName);
         this.httpConnectorRegistry.unregisterServerConnector(this.listenerUrl);
 
-        HTTPSourceRegistry.removeServiceSource(sourceId);
+        HTTPSourceRegistry.getInstance().removeServiceSource(sourceId);
         for (Map.Entry<String, HttpCarbonMessage> entry : requestContainerMap.entrySet()) {
             cancelRequest(entry.getKey(), entry.getValue());
         }
@@ -407,7 +407,7 @@ public class HttpServiceSource extends HttpSource {
     @Override
     public void destroy() {
         this.httpConnectorRegistry.clearBootstrapConfigIfLast();
-        HTTPSourceRegistry.removeServiceSource(sourceId);
+        HTTPSourceRegistry.getInstance().removeServiceSource(sourceId);
         timer.stop();
     }
 

--- a/component/src/main/java/io/siddhi/extension/io/http/source/HttpSyncWorkerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/source/HttpSyncWorkerThread.java
@@ -64,7 +64,7 @@ public class HttpSyncWorkerThread implements Runnable {
             String payload = buf.lines().collect(Collectors.joining("\n"));
 
             if (!payload.equals(HttpConstants.EMPTY_STRING)) {
-                HTTPSourceRegistry.getServiceSource(sourceId).registerCallback(carbonMessage, messageId);
+                HTTPSourceRegistry.getInstance().getServiceSource(sourceId).registerCallback(carbonMessage, messageId);
                 sourceEventListener.onEvent(payload, trpProperties);
                 if (logger.isDebugEnabled()) {
                     logger.debug("Submitted Event " + payload + " Stream");

--- a/component/src/main/java/io/siddhi/extension/io/http/util/ResponseSourceId.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/util/ResponseSourceId.java
@@ -52,7 +52,7 @@ public class ResponseSourceId {
         if (sinkId != null ? !sinkId.equals(that.sinkId) : that.sinkId != null) {
             return false;
         }
-        return httpCode != null ? httpCode.matches(that.httpCode) : that.httpCode == null;
+        return httpCode != null ? httpCode.equals(that.httpCode) : that.httpCode == null;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Add support to respond to multiple HttpCallResponseSources
> Make HttpSourceRegistry a singleton
> Fix ResponseSourceID equals method

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes