### PR TITLE
Http sink related bug fixes

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
@@ -671,7 +671,7 @@ public class HttpSink extends Sink {
         //if authentication fails then get the new access token
         if (response == HttpConstants.AUTHENTICATION_FAIL_CODE) {
             handleOAuthFailure(payload, dynamicOptions, headersList, encodedAuth, clientConnector);
-        } else if (response == HttpConstants.SUCCESS_CODE) {
+        } else if (HttpConstants.SUCCESS_CODE <= response && response < HttpConstants.MULTIPLE_CHOICES) {
             log.info("Request sent successfully to " + clientConnector.getPublisherURL());
         } else if (response == HttpConstants.INTERNAL_SERVER_FAIL_CODE) {
             log.error("Error at sending oauth request to API endpoint " + clientConnector.getPublisherURL() +

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/updatetoken/HttpsClient.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/updatetoken/HttpsClient.java
@@ -67,7 +67,8 @@ public class HttpsClient {
     private static String getPayload(Map<String, String> refreshTokenBody) {
         return refreshTokenBody.entrySet().stream()
                 .map(p -> encodeMessage(p.getKey()) + "=" + encodeMessage(p.getValue()))
-                .reduce("", (p1, p2) -> p1 + "&" + p2);
+                .reduce((p1, p2) -> p1 + "&" + p2)
+                .orElse("");
     }
 
     private static HashMap<String, String> setHeaders(String encodedAuth) {

--- a/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
@@ -202,6 +202,7 @@ public class HttpConstants {
     public static final String USERNAME = "username";
     public static final String PASSWORD = "password";
     public static final int SUCCESS_CODE = 200;
+    public static final int MULTIPLE_CHOICES = 300;
     public static final int CLIENT_REQUEST_TIMEOUT = 408;
     public static final int AUTHENTICATION_FAIL_CODE = 401;
     public static final int PERSISTENT_ACCESS_FAIL_CODE = 400;


### PR DESCRIPTION
## Purpose
Fix
https://github.com/siddhi-io/siddhi-io-http/issues/165
https://github.com/siddhi-io/siddhi-io-http/issues/166

## Approach
Since only HTTP status code 200 is considered as success in current implementation, all other 2XX based codes are consiredered as errors and retry happens. Fixed to handle all 200 based types.
The payload send to get a token here looks like following in current implementation &username=abc&password=123&grant_type=password When this is sent to /token endpoint it will throw an exception since the payload cannot be parsed due to the first character being '&'" -m "Fixed by changing the payload generation.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
