### PR TITLE
Update HttpSinkUtil.java

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
@@ -222,6 +222,9 @@ public class HttpSinkUtil {
 
             case HttpConstants.MAP_JSON:
                 return HttpConstants.APPLICATION_JSON;
+            
+            case HttpConstants.MAP_KEYVALUE:
+                return HttpConstants.APPLICATION_URL_ENCODED;
 
             default: {
                 log.info("Invalid payload map type. System support only text," +


### PR DESCRIPTION
Support key-value map

`
@sink(type = 'http', publisher.url = "https://api.tapd.cn/bugs", method = "POST", 
basic.auth.username='xxxx',basic.auth.password='xxxxx',@map(type = 'keyvalue',
@payload(workspace_id='xxx',title='xxxx',module='xxx',reporter='xxx',description='xxx',current_owner='xxx',deadline='2020-4-30')))
define stream SaveTapdStream (reporter string,module string,createtime string,desc string);
`

`[2020-04-28 14:02:07,556]  INFO {io.siddhi.extension.io.http.sink.util.HttpSinkUtil} - Invalid payload map type. System support only text,Json and XML type hence proceed with default text mapping`