### PR TITLE
Hide exceptions when remote client close the connection

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/source/HTTPConnectorListener.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/source/HTTPConnectorListener.java
@@ -26,6 +26,7 @@ import org.wso2.transport.http.netty.contract.Constants;
 import org.wso2.transport.http.netty.contract.HttpClientConnector;
 import org.wso2.transport.http.netty.contract.HttpConnectorListener;
 import org.wso2.transport.http.netty.contract.config.TransportsConfiguration;
+import org.wso2.transport.http.netty.contract.exceptions.ClientClosedConnectionException;
 import org.wso2.transport.http.netty.contract.exceptions.ServerConnectorException;
 import org.wso2.transport.http.netty.message.HttpCarbonMessage;
 
@@ -112,6 +113,10 @@ public class HTTPConnectorListener implements HttpConnectorListener {
 
     @Override
     public void onError(Throwable throwable) {
-        log.error("Error in http server connector", throwable);
+        if (throwable instanceof ClientClosedConnectionException) {
+            log.debug("Error in http server connector", throwable);
+        } else {
+            log.error("Error in http server connector", throwable);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
         <pax.url.aether.version>1.6.0</pax.url.aether.version>
         <maven.paxexam.plugin.version>1.2.4</maven.paxexam.plugin.version>
         <carbon.kernel.version>5.2.6</carbon.kernel.version>
-        <org.wso2.transport.http.version>6.1.9</org.wso2.transport.http.version>
+        <org.wso2.transport.http.version>6.3.9-SNAPSHOT</org.wso2.transport.http.version>
         <org.wso2.transport.http.version.range>[6.0.0,7.0.0)</org.wso2.transport.http.version.range>
         <commons-io.version>2.4.0.wso2v1</commons-io.version>
         <commons.lang3.version>3.7</commons.lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
         <pax.url.aether.version>1.6.0</pax.url.aether.version>
         <maven.paxexam.plugin.version>1.2.4</maven.paxexam.plugin.version>
         <carbon.kernel.version>5.2.6</carbon.kernel.version>
-        <org.wso2.transport.http.version>6.3.9-SNAPSHOT</org.wso2.transport.http.version>
+        <org.wso2.transport.http.version>6.3.9</org.wso2.transport.http.version>
         <org.wso2.transport.http.version.range>[6.0.0,7.0.0)</org.wso2.transport.http.version.range>
         <commons-io.version>2.4.0.wso2v1</commons-io.version>
         <commons.lang3.version>3.7</commons.lang3.version>


### PR DESCRIPTION
## Purpose
This PR hides the exceptions when the remote client abruptly closes the connection with the server.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
