### PR TITLE
Private package transport-http and io-netty

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -128,10 +128,16 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.transport.http.netty.*;version="${org.wso2.transport.http.version}",
+                            io.netty.*;version="${io.netty.version}"
+                        </Private-Package>
                         <Export-Package>
                             io.siddhi.extension.io.http.*
                         </Export-Package>
                         <Import-Package>
+                            !org.wso2.transport.http.netty.*,
+                            !io.netty.*,
                             io.siddhi.core.*;version="${siddhi.version.range}",
                             io.siddhi.annotation.*;version="${siddhi.version.range}",
                             io.siddhi.query.api.*;version="${siddhi.version.range}",


### PR DESCRIPTION
## Purpose
> Currently, IO-HTTP has to depend on the version exported with MSF4J. And cannot get the latest fixes sent for transport-http without changing msf4j

## Goals
> $subject

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes