### PR TITLE
Allow client credentials to be sent in the token request body

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
@@ -184,7 +184,7 @@ import static org.wso2.carbon.analytics.idp.client.external.ExternalIdPClientCon
                         optional = true,
                         defaultValue = "-"),
                 @Parameter(
-                        name = HttpConstants.OAuth2_SCOPE_PARAMETER_NAME,
+                        name = HttpConstants.OAUTH2_SCOPE_PARAMETER_NAME,
                         description = "Standard OAuth 2.0 scope parameter",
                         type = {DataType.STRING},
                         optional = true,
@@ -529,7 +529,8 @@ public class HttpSink extends Sink {
         this.consumerKey = optionHolder.validateAndGetStaticValue(HttpConstants.CONSUMER_KEY, EMPTY_STRING);
         this.consumerSecret = optionHolder.validateAndGetStaticValue(HttpConstants.CONSUMER_SECRET, EMPTY_STRING);
         this.bodyConsumerKey = optionHolder.validateAndGetStaticValue(HttpConstants.BODY_CONSUMER_KEY, EMPTY_STRING);
-        this.bodyConsumerSecret = optionHolder.validateAndGetStaticValue(HttpConstants.BODY_CONSUMER_SECRET, EMPTY_STRING);
+        this.bodyConsumerSecret = optionHolder.validateAndGetStaticValue(HttpConstants.BODY_CONSUMER_SECRET,
+                EMPTY_STRING);
         this.oauthUsername = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_OAUTH_USERNAME,
                 EMPTY_STRING);
         this.oauthUserPassword = optionHolder.validateAndGetStaticValue(HttpConstants.RECEIVER_OAUTH_PASSWORD,
@@ -538,8 +539,8 @@ public class HttpSink extends Sink {
         this.tokenURL = optionHolder.validateAndGetStaticValue(HttpConstants.TOKEN_URL, EMPTY_STRING);
         this.clientStoreFile = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_TRUSTSTORE_PATH_PARAM,
                 HttpSinkUtil.trustStorePath(configReader));
-        this.oauth2Scope = optionHolder.validateAndGetStaticValue(HttpConstants.OAuth2_SCOPE_PARAMETER_NAME,
-                HttpSinkUtil.trustStorePath(configReader));
+        this.oauth2Scope = optionHolder.validateAndGetStaticValue(HttpConstants.OAUTH2_SCOPE_PARAMETER_NAME,
+                EMPTY_STRING);
         clientStorePass = optionHolder.validateAndGetStaticValue(HttpConstants.CLIENT_TRUSTSTORE_PASSWORD_PARAM,
                 HttpSinkUtil.trustStorePassword(configReader));
         socketIdleTimeout = Integer.parseInt(optionHolder.validateAndGetStaticValue
@@ -1035,7 +1036,8 @@ public class HttpSink extends Sink {
             publisherURL = publisherURLOption.getValue(dynamicOptions);
         }
         if (authType.equals(HttpConstants.OAUTH)) {
-            if (EMPTY_STRING.equals(consumerSecret) || EMPTY_STRING.equals(consumerKey)) {
+            if ((EMPTY_STRING.equals(consumerSecret) || EMPTY_STRING.equals(consumerKey)) &&
+                    (EMPTY_STRING.equals(bodyConsumerKey) || EMPTY_STRING.equals(bodyConsumerSecret))) {
                 throw new SiddhiAppCreationException(HttpConstants.CONSUMER_KEY + " and " +
                         HttpConstants.CONSUMER_SECRET + " found empty but it is Mandatory field in " +
                         HttpConstants.HTTP_SINK_ID + " in " + streamID);

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/updatetoken/HttpsClient.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/updatetoken/HttpsClient.java
@@ -92,7 +92,7 @@ public class HttpsClient {
         refreshTokenBody.put(HttpConstants.USERNAME, username);
         refreshTokenBody.put(HttpConstants.PASSWORD, password);
         if (!HttpConstants.EMPTY_STRING.equals(oAuth2Scope)) {
-            refreshTokenBody.put(HttpConstants.OAuth2_SCOPE_PARAMETER_KEY, oAuth2Scope);
+            refreshTokenBody.put(HttpConstants.OAUTH2_SCOPE_PARAMETER_KEY, oAuth2Scope);
         }
 
         if (!HttpConstants.EMPTY_STRING.equals(consumerKey)) {

--- a/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
@@ -58,6 +58,8 @@ public class HttpConstants {
     public static final String DEFAULT_ENCODING = "UTF-8";
     public static final String DOWNLOAD_ENABLED = "downloading.enabled";
     public static final String DEFAULT_DOWNLOAD_ENABLED_VALUE = "false";
+    public static final String OAuth2_SCOPE_PARAMETER_NAME = "oauth.scope";
+    public static final String OAuth2_SCOPE_PARAMETER_KEY = "scope";
     //Common util values
     public static final String HTTP_METHOD_POST = "POST"; //method name
     public static final String HTTP_METHOD_OPTIONS = "OPTIONS";
@@ -195,6 +197,8 @@ public class HttpConstants {
     public static final String TOKEN_URL = "token.url";
     public static final String CONSUMER_SECRET = "consumer.secret";
     public static final String CONSUMER_KEY = "consumer.key";
+    public static final String BODY_CONSUMER_SECRET = "body.consumer.secret";
+    public static final String BODY_CONSUMER_KEY = "body.consumer.key";
     public static final String GRANT_TYPE = "grant_type";
     public static final String GRANT_PASSWORD = "password";
     public static final String GRANT_REFRESHTOKEN = "refresh_token";
@@ -207,6 +211,8 @@ public class HttpConstants {
     public static final int AUTHENTICATION_FAIL_CODE = 401;
     public static final int PERSISTENT_ACCESS_FAIL_CODE = 400;
     public static final int INTERNAL_SERVER_FAIL_CODE = 500;
+    public static final String OAUTH_CLIENT_ID = "client_id";
+    public static final String OAUTH_CLIENT_SECRET = "client_secret";
     public static final String RECEIVER_OAUTH_USERNAME = "oauth.username";
     public static final String RECEIVER_OAUTH_PASSWORD = "oauth.password";
     public static final String RECEIVER_REFRESH_TOKEN = "refresh.token";

--- a/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
@@ -58,8 +58,8 @@ public class HttpConstants {
     public static final String DEFAULT_ENCODING = "UTF-8";
     public static final String DOWNLOAD_ENABLED = "downloading.enabled";
     public static final String DEFAULT_DOWNLOAD_ENABLED_VALUE = "false";
-    public static final String OAuth2_SCOPE_PARAMETER_NAME = "oauth.scope";
-    public static final String OAuth2_SCOPE_PARAMETER_KEY = "scope";
+    public static final String OAUTH2_SCOPE_PARAMETER_NAME = "oauth.scope";
+    public static final String OAUTH2_SCOPE_PARAMETER_KEY = "scope";
     //Common util values
     public static final String HTTP_METHOD_POST = "POST"; //method name
     public static final String HTTP_METHOD_OPTIONS = "OPTIONS";


### PR DESCRIPTION
## Purpose
Allow client credentials to be sent in the token request body and fix password grant always requiring to have refresh token in the response

## Approach
Some oAuth Providers require client credentials to be sent in the token request body as seen in [here](https://docs.akana.com/cm/api_oauth/aaref/Ref_OAuth_ClientAuthenticationWithOAuthProvider.htm#getting_access_token_using_resource_owner_password_credentials_grant_type) our client only supports sending client credentials in the Authrorization Header and this PR fixes that.

in order to fix that I have added 3 new attributes as follows
 - `body.consumer.key` - configure only when the client credential required to be sent in the request body
 - `body.consumer.secret`- configure only when the client credential required to be sent in the request body
 - `oauth.scope` - oAuth scope parameter


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8.0_211