### PR TITLE
Fix executor service creation and memory releasing issue

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/HttpSink.java
@@ -320,6 +320,12 @@ import static org.wso2.carbon.analytics.idp.client.external.ExternalIdPClientCon
                         optional = true,
                         defaultValue = "100"),
                 @Parameter(
+                        name = "executor.service.threads",
+                        description = "Thread count for the executor service.",
+                        type = {DataType.INT},
+                        optional = true,
+                        defaultValue = "20"),
+                @Parameter(
                         name = "min.evictable.idle.time",
                         description = "Minimum time (in millis) a connection may sit idle in the " +
                                 "client pool before it become eligible for eviction.",
@@ -565,6 +571,8 @@ public class HttpSink extends Sink {
 
         //pool configurations
         connectionPoolConfiguration = createPoolConfigurations(optionHolder);
+
+        executor = Executors.newFixedThreadPool(connectionPoolConfiguration.getExecutorServiceThreads());
 
         parametersList = optionHolder.validateAndGetStaticValue(HttpConstants.SINK_PARAMETERS, EMPTY_STRING);
 
@@ -1160,9 +1168,6 @@ public class HttpSink extends Sink {
         if (TRUE.equalsIgnoreCase(sslVerificationDisabled)) {
             senderConfig.disableSsl();
         }
-
-        executor = Executors.newFixedThreadPool(
-                senderConfig.getPoolConfiguration().getExecutorServiceThreads());
 
         //overwrite default transport configuration
         Map<String, Object> bootStrapProperties = HttpSinkUtil

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/SSEWorkerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/SSEWorkerThread.java
@@ -58,9 +58,10 @@ public class SSEWorkerThread implements Runnable {
 
         try {
             buf.close();
-            carbonMessage.waitAndReleaseAllEntities();
         } catch (IOException e) {
             logger.error("Error occurred when closing the byte buffer in source " + streamID, e);
+        } finally {
+            carbonMessage.waitAndReleaseAllEntities();
         }
     }
 }

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/WebSubHubSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/WebSubHubSink.java
@@ -300,6 +300,12 @@ import static org.wso2.carbon.analytics.idp.client.external.ExternalIdPClientCon
                         optional = true,
                         defaultValue = "100"),
                 @Parameter(
+                        name = "executor.service.threads",
+                        description = "Thread count for the executor service.",
+                        type = {DataType.INT},
+                        optional = true,
+                        defaultValue = "20"),
+                @Parameter(
                         name = "min.evictable.idle.time",
                         description = "Minimum time (in millis) a connection may sit idle in the " +
                                 "client pool before it become eligible for eviction.",
@@ -490,6 +496,7 @@ public class WebSubHubSink extends Sink {
 
         //pool configurations
         connectionPoolConfiguration = createPoolConfigurations(optionHolder);
+        executor = Executors.newFixedThreadPool(connectionPoolConfiguration.getExecutorServiceThreads());
         parametersList = optionHolder.validateAndGetStaticValue(HttpConstants.SINK_PARAMETERS, EMPTY_STRING);
         clientBootstrapConfiguration = optionHolder
                 .validateAndGetStaticValue(HttpConstants.CLIENT_BOOTSTRAP_CONFIGURATION, EMPTY_STRING);
@@ -760,9 +767,6 @@ public class WebSubHubSink extends Sink {
             senderConfig.disableSsl();
         }
 
-        executor = Executors.newFixedThreadPool(
-                senderConfig.getPoolConfiguration().getExecutorServiceThreads());
-
         //overwrite default transport configuration
         Map<String, Object> bootStrapProperties = HttpSinkUtil
                 .populateTransportConfiguration(clientBootstrapConfiguration);
@@ -822,7 +826,6 @@ public class WebSubHubSink extends Sink {
         this.onDemandQueryRuntime = OnDemandQueryParser.parse(onDemandQuery, null,
                 siddhiAppContext, tableMap, windowMap, aggregationRuntimeMap);
     }
-
 
     public void setWebSubSubscriptionMap(Map<String, List<WebSubSubscriptionDTO>> webSubSubscriptionMap) {
         this.webSubSubscriptionMap = webSubSubscriptionMap;

--- a/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
@@ -295,6 +295,8 @@ public class HttpSinkUtil {
     }
 
     public static PoolConfiguration createPoolConfigurations(OptionHolder optionHolder) {
+        int executorServiceThreads = Integer.parseInt(optionHolder.validateAndGetStaticValue(
+                HttpConstants.EXECUTOR_SERVICE_THREAD_COUNT, HttpConstants.DEFAULT_EXECUTOR_SERVICE_THREAD_COUNT));
         int maxIdlePerPool = Integer.parseInt(optionHolder.validateAndGetStaticValue(
                 HttpConstants.MAX_IDLE_CONNECTIONS_PER_POOL, HttpConstants.DEFAULT_MAX_IDLE_CONNECTIONS_PER_POOL));
         int minIdlePerPool = Integer.parseInt(optionHolder.validateAndGetStaticValue(
@@ -315,6 +317,7 @@ public class HttpSinkUtil {
         int maxWaitTime = Integer.parseInt(optionHolder.validateAndGetStaticValue(
                 HttpConstants.MAX_WAIT_TIME, HttpConstants.DEFAULT_MAX_WAIT_TIME));
         PoolConfiguration connectionPoolConfiguration = new PoolConfiguration();
+        connectionPoolConfiguration.setExecutorServiceThreads(executorServiceThreads);
         connectionPoolConfiguration.setMaxActivePerPool(maxActivePerPool);
         connectionPoolConfiguration.setMinIdlePerPool(minIdlePerPool);
         connectionPoolConfiguration.setMaxIdlePerPool(maxIdlePerPool);

--- a/component/src/main/java/io/siddhi/extension/io/http/source/HttpSyncWorkerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/source/HttpSyncWorkerThread.java
@@ -94,13 +94,13 @@ public class HttpSyncWorkerThread implements Runnable {
         } finally {
             try {
                 buf.close();
-                carbonMessage.waitAndReleaseAllEntities();
             } catch (IOException e) {
                 if (metrics != null) {
                     metrics.getTotalHttpErrorsMetric().inc();
                 }
-
                 logger.error("Error occurred when closing the byte buffer in source " + sourceID, e);
+            } finally {
+                carbonMessage.waitAndReleaseAllEntities();
             }
         }
     }

--- a/component/src/main/java/io/siddhi/extension/io/http/source/HttpWebSubResponseProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/source/HttpWebSubResponseProcessor.java
@@ -192,12 +192,13 @@ public class HttpWebSubResponseProcessor implements Runnable {
         } finally {
             try {
                 buf.close();
-                carbonMessage.waitAndReleaseAllEntities();
             } catch (IOException e) {
                 if (metrics != null) {
                     metrics.getTotalHttpErrorsMetric().inc();
                 }
                 logger.error("Error occurred when closing the byte buffer in source " + sourceID, e);
+            } finally {
+                carbonMessage.waitAndReleaseAllEntities();
             }
         }
     }

--- a/component/src/main/java/io/siddhi/extension/io/http/source/HttpWorkerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/source/HttpWorkerThread.java
@@ -88,13 +88,13 @@ public class HttpWorkerThread implements Runnable {
         } finally {
             try {
                 buf.close();
-                carbonMessage.waitAndReleaseAllEntities();
             } catch (IOException e) {
                 if (metrics != null) {
                     metrics.getTotalHttpErrorsMetric().inc();
                 }
-
                 logger.error("Error occurred when closing the byte buffer in source " + sourceID, e);
+            } finally {
+                carbonMessage.waitAndReleaseAllEntities();
             }
         }
     }

--- a/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
@@ -231,6 +231,8 @@ public class HttpConstants {
     public static final String BLOCKING_IO = "blocking.io";
 
     //pool configurations
+    public static final String EXECUTOR_SERVICE_THREAD_COUNT = "executor.service.threads";
+    public static final String DEFAULT_EXECUTOR_SERVICE_THREAD_COUNT = "20";
     public static final String MAX_ACTIVE_CONNECTIONS_PER_POOL = "max.pool.active.connections";
     public static final String DEFAULT_MAX_ACTIVE_CONNECTIONS_PER_POOL = "-1"; // unlimited
     public static final String MIN_IDLE_CONNECTIONS_PER_POOL = "min.pool.idle.connections";


### PR DESCRIPTION
## Purpose
- Make client consumer `executor.service.threads` count configurable.
- Move executor service creation to init method (to avoid multiple calls to executor service creation).
- Release Netty resources.

@tishan89 @mohanvive @ramindu90 @AnuGayan @pcnfernando @gimantha Please review and merge.