### PR TITLE
Fix jaxb depedency issue

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -102,6 +102,18 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,21 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <properties>
@@ -292,6 +307,7 @@
         <commons.codec.version>1.15</commons.codec.version>
         <okhttp.client.version>4.8.1</okhttp.client.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
+        <jaxb.version>2.3.0</jaxb.version>
     </properties>
     <build>
         <extensions>


### PR DESCRIPTION
## Purpose
> Fix the following error due to the javax-xml-bind version issue
```
Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.3:jar (attach-javadocs) on project siddhi-io-http: MavenReportException: Error while generating Javadoc: 
[INFO] [ERROR] Exit code: 1 - warning: unknown enum constant XmlAccessType.FIELD
[INFO] [ERROR]   reason: class file for javax.xml.bind.annotation.XmlAccessType not found
[INFO] [ERROR] warning: unknown enum constant XmlAccessType.FIELD
[INFO] [ERROR] warning: unknown enum constant XmlAccessType.FIELD
[INFO] [ERROR] javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
```