### PR TITLE
Fix java-doc dependency issue

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -230,6 +230,28 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <!--This parameter disables doclint-->
+                            <doclint>none</doclint>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>1.8</source>
+                    <attach>true</attach>
+                    <additionalJOption>-Xdoclint:none</additionalJOption>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,7 @@
         <okhttp.client.version>4.8.1</okhttp.client.version>
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
         <jaxb.version>2.3.0</jaxb.version>
+        <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
     </properties>
     <build>
         <extensions>


### PR DESCRIPTION
## Purpose
> The following error throw as it cannot identify java-doc-pluging
```
INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.3:jar (attach-javadocs) on project siddhi-io-http: MavenReportException: Error while generating Javadoc: 
[INFO] [ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
```