### PR TITLE
Secure http client in http sink

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/sink/util/HttpSinkUtil.java
@@ -151,6 +151,40 @@ public class HttpSinkUtil {
     }
 
     /**
+     * user can give custom key store file if user did not give then custom then system read the default values which is
+     * in the deployment yaml.
+     *
+     * @param sinkConfigReader configuration reader for sink.
+     * @return key store file path.
+     */
+    public static String keyStorePath(ConfigReader sinkConfigReader) {
+        return sinkConfigReader.readConfig(HttpConstants.KEYSTORE_FILE, HttpConstants.KEYSTORE_FILE_VALUE);
+    }
+
+    /**
+     * user can give custom keystore password,, if user did not give then custom then system read the default values
+     * which is in the deployment yaml.
+     *
+     * @param sinkConfigReader configuration reader for sink.
+     * @return key store password.
+     */
+    public static String keyStorePassword(ConfigReader sinkConfigReader) {
+        return sinkConfigReader.readConfig(HttpConstants.KEYSTORE_PASSWORD, HttpConstants.KEYSTORE_PASSWORD_VALUE);
+    }
+
+    /**
+     * user can give custom key store key password if user did not give then custom then system read the default values
+     * which is in the deployment yaml.
+     *
+     * @param sinkConfigReader configuration reader for sink.
+     * @return key store key password.
+     */
+    public static String keyPassword(ConfigReader sinkConfigReader) {
+        return sinkConfigReader.readConfig(HttpConstants.KEYSTORE_KEY_PASSWORD,
+                HttpConstants.KEYSTORE_KEY_PASSWORD_VALUE);
+    }
+
+    /**
      * Method is responsible for set sender configuration values .
      *
      * @param httpStaticProperties the map that url details.

--- a/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/http/util/HttpConstants.java
@@ -101,10 +101,15 @@ public class HttpConstants {
     public static final String CLIENT_TRUSTSTORE_PASSWORD = "trustStorePassword";
     public static final String CLIENT_TRUSTSTORE_PASSWORD_PARAM = "https.truststore.password";
     public static final String CLIENT_TRUSTSTORE_PASSWORD_VALUE = "wso2carbon";
+    public static final String KEYSTORE_PATH_PARAM = "https.keystore.file";
     public static final String KEYSTORE_FILE = "keyStoreLocation";
     public static final String KEYSTORE_FILE_VALUE = "${carbon.home}/resources/security/wso2carbon.jks";
+    public static final String KEYSTORE_PASSWORD_PARAM = "https.keystore.password";
     public static final String KEYSTORE_PASSWORD = "keyStorePassword";
     public static final String KEYSTORE_PASSWORD_VALUE = "wso2carbon";
+    public static final String KEYSTORE_KEY_PASSWORD_PARAM = "https.keystore.key.password";
+    public static final String KEYSTORE_KEY_PASSWORD = "keyPassword";
+    public static final String KEYSTORE_KEY_PASSWORD_VALUE = "wso2carbon";
 
     public static final String DEFAULT_SOURCE_SCHEME = "defaultScheme";
     public static final String DEFAULT_SOURCE_SCHEME_VALUE = "http";


### PR DESCRIPTION
$subject

This removes the dummy certification validation process that validates any certificates that were present in the http client connections to use the trust store to find the trusted certificates. The usage of SSL is also replaced by TLS